### PR TITLE
feat: 투표 평가 기능 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -114,3 +114,25 @@ Content-Type: image/jpeg
 
 ===== 응답
 include::{snippets}/투표_등록_테스트/투표_등록_성공/http-response.adoc[]
+
+---
+
+=== 📌 투표 평가
+==== 기본정보
+- 메서드 : POST
+- URL : `/api/votes/{vote-id}/evaluations`
+
+==== 요청
+===== 헤더
+include::{snippets}/투표_평가_테스트/투표_평가_성공/request-headers.adoc[]
+===== 경로 변수
+include::{snippets}/투표_평가_테스트/투표_평가_성공/path-parameters.adoc[]
+===== 본문
+include::{snippets}/투표_평가_테스트/투표_평가_성공/request-fields.adoc[]
+==== 예시
+===== 요청
+include::{snippets}/투표_평가_테스트/투표_평가_성공/http-request.adoc[]
+===== 응답
+include::{snippets}/투표_평가_테스트/투표_평가_성공/http-response.adoc[]
+
+---

--- a/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
+++ b/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
@@ -6,7 +6,13 @@ import com.salmalteam.salmal.domain.image.ImageFile;
 import com.salmalteam.salmal.domain.member.Member;
 import com.salmalteam.salmal.domain.vote.Vote;
 import com.salmalteam.salmal.domain.vote.VoteRepository;
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluation;
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationRepository;
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
 import com.salmalteam.salmal.dto.request.vote.VoteCreateRequest;
+import com.salmalteam.salmal.dto.request.vote.VoteEvaluateRequest;
+import com.salmalteam.salmal.exception.vote.VoteException;
+import com.salmalteam.salmal.exception.vote.VoteExceptionType;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -18,15 +24,18 @@ public class VoteService {
 
     private final MemberService memberService;
     private final VoteRepository voteRepository;
+    private final VoteEvaluationRepository voteEvaluationRepository;
     private final ImageUploader imageUploader;
     private final String voteImagePath;
 
     public VoteService(final MemberService memberService,
                        final VoteRepository voteRepository,
+                       final VoteEvaluationRepository voteEvaluationRepository,
                        final ImageUploader imageUploader,
                        @Value("${image.path.vote}") String voteImagePath){
         this.memberService = memberService;
         this.voteRepository = voteRepository;
+        this.voteEvaluationRepository = voteEvaluationRepository;
         this.imageUploader = imageUploader;
         this.voteImagePath = voteImagePath;
     }
@@ -37,5 +46,28 @@ public class VoteService {
         final String imageUrl = imageUploader.uploadImage(ImageFile.of(multipartFile, voteImagePath));
         final Member member = memberService.findMemberById(memberPayLoad.getId());
         voteRepository.save(Vote.of(imageUrl, member));
+    }
+
+    @Transactional
+    public void evaluate(final MemberPayLoad memberPayLoad, final Long voteId, final VoteEvaluateRequest voteEvaluateRequest){
+
+        final Member member = memberService.findMemberById(memberPayLoad.getId());
+        final Vote vote = getVoteById(voteId);
+        final VoteEvaluationType voteEvaluationType = voteEvaluateRequest.getVoteEvaluationType();
+
+        validateEvaluationVoteDuplicated(member, vote, voteEvaluationType);
+
+        voteEvaluationRepository.save(VoteEvaluation.of(vote, member, voteEvaluationType));
+    }
+
+    private Vote getVoteById(final Long voteId){
+        return voteRepository.findById(voteId)
+                .orElseThrow(() -> new VoteException(VoteExceptionType.NOT_FOUND));
+    }
+
+    private void validateEvaluationVoteDuplicated(final Member member,final Vote vote, final VoteEvaluationType voteEvaluationType) {
+        if(voteEvaluationRepository.existsByEvaluatorAndVoteAndVoteEvaluationType(member, vote, voteEvaluationType)){
+            throw new VoteException(VoteExceptionType.DUPLICATED_VOTE_EVALUATION);
+        }
     }
 }

--- a/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
+++ b/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
@@ -49,11 +49,10 @@ public class VoteService {
     }
 
     @Transactional
-    public void evaluate(final MemberPayLoad memberPayLoad, final Long voteId, final VoteEvaluateRequest voteEvaluateRequest){
+    public void evaluate(final MemberPayLoad memberPayLoad, final Long voteId, final VoteEvaluationType voteEvaluationType){
 
         final Member member = memberService.findMemberById(memberPayLoad.getId());
         final Vote vote = getVoteById(voteId);
-        final VoteEvaluationType voteEvaluationType = voteEvaluateRequest.getVoteEvaluationType();
 
         validateEvaluationVoteDuplicated(member, vote, voteEvaluationType);
 

--- a/src/main/java/com/salmalteam/salmal/domain/member/evaluation/EvaluationVoteRepository.java
+++ b/src/main/java/com/salmalteam/salmal/domain/member/evaluation/EvaluationVoteRepository.java
@@ -1,6 +1,0 @@
-package com.salmalteam.salmal.domain.member.evaluation;
-
-import org.springframework.data.repository.Repository;
-
-public interface EvaluationVoteRepository extends Repository<EvaluationVote, Long> {
-}

--- a/src/main/java/com/salmalteam/salmal/domain/vote/VoteRepository.java
+++ b/src/main/java/com/salmalteam/salmal/domain/vote/VoteRepository.java
@@ -2,6 +2,9 @@ package com.salmalteam.salmal.domain.vote;
 
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
 public interface VoteRepository extends Repository<Vote, Long>, VoteRepositoryCustom {
     Vote save(Vote vote);
+    Optional<Vote> findById(Long id);
 }

--- a/src/main/java/com/salmalteam/salmal/domain/vote/evaluation/VoteEvaluation.java
+++ b/src/main/java/com/salmalteam/salmal/domain/vote/evaluation/VoteEvaluation.java
@@ -1,4 +1,4 @@
-package com.salmalteam.salmal.domain.member.evaluation;
+package com.salmalteam.salmal.domain.vote.evaluation;
 
 import com.salmalteam.salmal.domain.BaseCreatedTimeEntity;
 import com.salmalteam.salmal.domain.member.Member;
@@ -11,9 +11,9 @@ import javax.persistence.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = {"id"})
-@Table(name = "evaluation_vote")
-public class EvaluationVote extends BaseCreatedTimeEntity {
+@EqualsAndHashCode(of = {"id"}, callSuper = true)
+@Table(name = "vote_evaluation")
+public class VoteEvaluation extends BaseCreatedTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,12 +27,16 @@ public class EvaluationVote extends BaseCreatedTimeEntity {
     @JoinColumn(name = "evaluator_id")
     private Member evaluator;
 
-    private EvaluationVote(final Vote vote, final Member member) {
+    @Enumerated(EnumType.STRING)
+    private VoteEvaluationType voteEvaluationType;
+
+    private VoteEvaluation(final Vote vote, final Member member, final VoteEvaluationType voteEvaluationType) {
         this.vote = vote;
         this.evaluator = member;
+        this.voteEvaluationType = voteEvaluationType;
     }
 
-    public static EvaluationVote of(final Vote vote, final Member member) {
-        return new EvaluationVote(vote, member);
+    public static VoteEvaluation of(final Vote vote, final Member member, final VoteEvaluationType voteEvaluationType) {
+        return new VoteEvaluation(vote, member, voteEvaluationType);
     }
 }

--- a/src/main/java/com/salmalteam/salmal/domain/vote/evaluation/VoteEvaluationRepository.java
+++ b/src/main/java/com/salmalteam/salmal/domain/vote/evaluation/VoteEvaluationRepository.java
@@ -1,0 +1,11 @@
+package com.salmalteam.salmal.domain.vote.evaluation;
+
+import com.salmalteam.salmal.domain.member.Member;
+import com.salmalteam.salmal.domain.vote.Vote;
+import org.springframework.data.repository.Repository;
+
+public interface VoteEvaluationRepository extends Repository<VoteEvaluation, Long> {
+    VoteEvaluation save(VoteEvaluation voteEvaluation);
+    boolean existsByEvaluatorAndVoteAndVoteEvaluationType(Member member, Vote vote, VoteEvaluationType voteEvaluationType);
+
+}

--- a/src/main/java/com/salmalteam/salmal/domain/vote/evaluation/VoteEvaluationType.java
+++ b/src/main/java/com/salmalteam/salmal/domain/vote/evaluation/VoteEvaluationType.java
@@ -1,0 +1,18 @@
+package com.salmalteam.salmal.domain.vote.evaluation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+
+public enum VoteEvaluationType {
+    LIKE,
+    DISLIKE;
+
+    @JsonCreator
+    public static VoteEvaluationType from(final String voteEvaluationType){
+        return Arrays.stream(VoteEvaluationType.values())
+                .filter(it -> it.name().equalsIgnoreCase(voteEvaluationType))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/salmalteam/salmal/domain/vote/evaluation/VoteEvaluationType.java
+++ b/src/main/java/com/salmalteam/salmal/domain/vote/evaluation/VoteEvaluationType.java
@@ -1,6 +1,7 @@
 package com.salmalteam.salmal.domain.vote.evaluation;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.salmalteam.salmal.exception.vote.VoteException;
+import com.salmalteam.salmal.exception.vote.VoteExceptionType;
 
 import java.util.Arrays;
 
@@ -8,11 +9,10 @@ public enum VoteEvaluationType {
     LIKE,
     DISLIKE;
 
-    @JsonCreator
     public static VoteEvaluationType from(final String voteEvaluationType){
         return Arrays.stream(VoteEvaluationType.values())
                 .filter(it -> it.name().equalsIgnoreCase(voteEvaluationType))
-                .findFirst()
-                .orElse(null);
+                .findAny()
+                .orElseThrow(() -> new VoteException(VoteExceptionType.INVALID_VOTE_EVALUATION_TYPE));
     }
 }

--- a/src/main/java/com/salmalteam/salmal/dto/request/vote/VoteEvaluateRequest.java
+++ b/src/main/java/com/salmalteam/salmal/dto/request/vote/VoteEvaluateRequest.java
@@ -1,0 +1,19 @@
+package com.salmalteam.salmal.dto.request.vote;
+
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class VoteEvaluateRequest {
+
+    @NotNull(message = "투표 타입을 입력해주세요(like, disLike)")
+    private VoteEvaluationType voteEvaluationType;
+    public VoteEvaluateRequest(final String voteEvaluationType){
+        this.voteEvaluationType = VoteEvaluationType.from(voteEvaluationType);
+    }
+}

--- a/src/main/java/com/salmalteam/salmal/dto/request/vote/VoteEvaluateRequest.java
+++ b/src/main/java/com/salmalteam/salmal/dto/request/vote/VoteEvaluateRequest.java
@@ -1,6 +1,5 @@
 package com.salmalteam.salmal.dto.request.vote;
 
-import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,9 +10,9 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class VoteEvaluateRequest {
 
-    @NotNull(message = "투표 타입을 입력해주세요(like, disLike)")
-    private VoteEvaluationType voteEvaluationType;
+    @NotNull(message = "투표 타입을 입력해주세요")
+    private String voteEvaluationType;
     public VoteEvaluateRequest(final String voteEvaluationType){
-        this.voteEvaluationType = VoteEvaluationType.from(voteEvaluationType);
+        this.voteEvaluationType = voteEvaluationType;
     }
 }

--- a/src/main/java/com/salmalteam/salmal/exception/vote/VoteExceptionType.java
+++ b/src/main/java/com/salmalteam/salmal/exception/vote/VoteExceptionType.java
@@ -7,6 +7,8 @@ public enum VoteExceptionType implements ExceptionType {
     NOT_FOUND(Status.NOT_FOUND, 3001, "투표를 찾을 수가 없습니다.", "존재하지 않는 투표 요청"),
     FORBIDDEN_DELETE(Status.FORBIDDEN, 3002, "투표를 삭제할 권한이 없습니다.", "권한이 없는 투표 삭제 요청"),
     FORBIDDEN_UPDATE(Status.FORBIDDEN, 3003, "투표를 수정할 권한이 없습니다.", "권한이 없는 투표 수정 요청"),
+    DUPLICATED_VOTE_EVALUATION(Status.BAD_REQUEST, 3004, "이미 평가를 한 투표입니다.", "중복된 투표 평가 요청"),
+    INVALID_VOTE_EVALUATION_TYPE(Status.BAD_REQUEST, 3005, "투표타입은 LIKE 또는 DISLIKE 입니다.", "적절하지 않은 투표 타입 요청");
     ;
 
     private final Status status;

--- a/src/main/java/com/salmalteam/salmal/presentation/vote/VoteController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/vote/VoteController.java
@@ -2,6 +2,7 @@ package com.salmalteam.salmal.presentation.vote;
 
 import com.salmalteam.salmal.application.vote.VoteService;
 import com.salmalteam.salmal.dto.request.vote.VoteCreateRequest;
+import com.salmalteam.salmal.dto.request.vote.VoteEvaluateRequest;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 import com.salmalteam.salmal.presentation.Login;
 import com.salmalteam.salmal.presentation.LoginMember;
@@ -20,8 +21,18 @@ public class VoteController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @Login
-    public void registerVote(@LoginMember MemberPayLoad memberPayLoad, @ModelAttribute @Valid final VoteCreateRequest voteCreateRequest){
+    public void registerVote(@LoginMember MemberPayLoad memberPayLoad,
+                             @ModelAttribute @Valid final VoteCreateRequest voteCreateRequest){
         voteService.register(memberPayLoad, voteCreateRequest);
+    }
+
+    @PostMapping("/{vote-id}/evaluations")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Login
+    public void evaluateVote(@LoginMember MemberPayLoad memberPayLoad,
+                             @PathVariable(name = "vote-id") final Long voteId,
+                             @RequestBody @Valid final VoteEvaluateRequest voteEvaluateRequest){
+        voteService.evaluate(memberPayLoad, voteId, voteEvaluateRequest);
     }
 
 }

--- a/src/main/java/com/salmalteam/salmal/presentation/vote/VoteController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/vote/VoteController.java
@@ -1,6 +1,7 @@
 package com.salmalteam.salmal.presentation.vote;
 
 import com.salmalteam.salmal.application.vote.VoteService;
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
 import com.salmalteam.salmal.dto.request.vote.VoteCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteEvaluateRequest;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
@@ -32,7 +33,8 @@ public class VoteController {
     public void evaluateVote(@LoginMember MemberPayLoad memberPayLoad,
                              @PathVariable(name = "vote-id") final Long voteId,
                              @RequestBody @Valid final VoteEvaluateRequest voteEvaluateRequest){
-        voteService.evaluate(memberPayLoad, voteId, voteEvaluateRequest);
+        final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluateRequest.getVoteEvaluationType());
+        voteService.evaluate(memberPayLoad, voteId, voteEvaluationType);
     }
 
 }

--- a/src/test/java/com/salmalteam/salmal/application/vote/VoteServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/vote/VoteServiceTest.java
@@ -5,7 +5,9 @@ import com.salmalteam.salmal.application.member.MemberService;
 import com.salmalteam.salmal.domain.member.Member;
 import com.salmalteam.salmal.domain.vote.Vote;
 import com.salmalteam.salmal.domain.vote.VoteRepository;
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluation;
 import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationRepository;
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
 import com.salmalteam.salmal.dto.request.vote.VoteCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteEvaluateRequest;
 import com.salmalteam.salmal.exception.vote.VoteException;
@@ -78,13 +80,13 @@ class VoteServiceTest {
             final Long memberId = 1L;
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long voteId = 1L;
-            final String voteEvaluationType = "LIKE";
-            final VoteEvaluateRequest voteEvaluateRequest = new VoteEvaluateRequest(voteEvaluationType);
+            final String voteEvaluationTypeStr = "LIKE";
+            final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluationTypeStr);
             given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
             given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluateRequest))
+            assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluationType))
                     .isInstanceOf(VoteException.class);
         }
 
@@ -94,15 +96,15 @@ class VoteServiceTest {
             final Long memberId = 1L;
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long voteId = 1L;
-            final String voteEvaluationType = "LIKE";
-            final VoteEvaluateRequest voteEvaluateRequest = new VoteEvaluateRequest(voteEvaluationType);
+            final String voteEvaluationTypeStr = "LIKE";
+            final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluationTypeStr);
 
             given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
             given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", Member.of("LLLLLLL", "닉네임", "KAKAO", true))));
             given(voteEvaluationRepository.existsByEvaluatorAndVoteAndVoteEvaluationType(any(), any(), any())).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluateRequest))
+            assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluationType))
                     .isInstanceOf(VoteException.class);
         }
     }

--- a/src/test/java/com/salmalteam/salmal/application/vote/VoteServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/vote/VoteServiceTest.java
@@ -3,8 +3,12 @@ package com.salmalteam.salmal.application.vote;
 import com.salmalteam.salmal.application.ImageUploader;
 import com.salmalteam.salmal.application.member.MemberService;
 import com.salmalteam.salmal.domain.member.Member;
+import com.salmalteam.salmal.domain.vote.Vote;
 import com.salmalteam.salmal.domain.vote.VoteRepository;
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationRepository;
 import com.salmalteam.salmal.dto.request.vote.VoteCreateRequest;
+import com.salmalteam.salmal.dto.request.vote.VoteEvaluateRequest;
+import com.salmalteam.salmal.exception.vote.VoteException;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,9 +20,12 @@ import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,10 +40,12 @@ class VoteServiceTest {
     @Mock
     VoteRepository voteRepository;
     @Mock
+    VoteEvaluationRepository voteEvaluationRepository;
+    @Mock
     ImageUploader imageUploader;
 
     @Nested
-    class 투표_업로드_테스트{
+    class 투표_업로드_테스트 {
         @Test
         void 이미지_업로더를_통해_업로드후_요청에_해당하는_회원을_찾은_뒤_저장한다() throws IOException {
             // given
@@ -57,6 +66,44 @@ class VoteServiceTest {
             verify(imageUploader, times(1)).uploadImage(any());
             verify(memberService, times(1)).findMemberById(any());
             verify(voteRepository, times(1)).save(any());
+        }
+    }
+
+    @Nested
+    class 투표_평가_테스트 {
+
+        @Test
+        void 평가를_할_투표가_존재하지_않는다면_에러를_발생시킨다() {
+            // given
+            final Long memberId = 1L;
+            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+            final Long voteId = 1L;
+            final String voteEvaluationType = "LIKE";
+            final VoteEvaluateRequest voteEvaluateRequest = new VoteEvaluateRequest(voteEvaluationType);
+            given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
+            given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluateRequest))
+                    .isInstanceOf(VoteException.class);
+        }
+
+        @Test
+        void 이미_동일한_타입의_투표를_이행한_적이_있다면_에러를_발생시킨다() {
+            // given
+            final Long memberId = 1L;
+            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+            final Long voteId = 1L;
+            final String voteEvaluationType = "LIKE";
+            final VoteEvaluateRequest voteEvaluateRequest = new VoteEvaluateRequest(voteEvaluationType);
+
+            given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
+            given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", Member.of("LLLLLLL", "닉네임", "KAKAO", true))));
+            given(voteEvaluationRepository.existsByEvaluatorAndVoteAndVoteEvaluationType(any(), any(), any())).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluateRequest))
+                    .isInstanceOf(VoteException.class);
         }
     }
 

--- a/src/test/java/com/salmalteam/salmal/presentation/vote/VoteControllerTest.java
+++ b/src/test/java/com/salmalteam/salmal/presentation/vote/VoteControllerTest.java
@@ -1,24 +1,35 @@
 package com.salmalteam.salmal.presentation.vote;
 
+import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
+import com.salmalteam.salmal.dto.request.vote.VoteEvaluateRequest;
 import com.salmalteam.salmal.support.PresentationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
-import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class VoteControllerTest extends PresentationTest {
@@ -78,6 +89,77 @@ class VoteControllerTest extends PresentationTest {
             // when & then
             mockMvc.perform(multipart(BASE_URL)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest());
+        }
+
+    }
+
+    @Nested
+    class 투표_평가_테스트{
+
+        private final static String URL = "/{vote-id}/evaluations";
+        @Test
+        void 투표_평가_성공() throws Exception{
+            // given
+            final Long voteId = 1L;
+            final String voteEvaluationType = "LIKE";
+            final VoteEvaluateRequest voteEvaluateRequest = new VoteEvaluateRequest(voteEvaluationType);
+
+            mockingForAuthorization();
+
+            // when
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL+URL, voteId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                            .content(createJson(voteEvaluateRequest))
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isCreated());
+
+            // then
+            resultActions.andDo(restDocs.document(
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 타입 AccessToken")
+                    ),
+                    pathParameters(
+                            parameterWithName("vote-id").description("평가할 투표 ID")
+                    ),
+                    requestFields(
+                            fieldWithPath("voteEvaluationType").type(JsonFieldType.STRING).description("투표 평가 타입 ( LIKE, DISLIKE )")
+                    )
+            ));
+
+            verify(voteService, times(1)).evaluate(any(), any(), any());
+
+        }
+
+        @Test
+        void 미인증_사용자일_경우_401_응답() throws Exception{
+
+            // given
+            final Long voteId = 1L;
+
+            // when & then
+            mockMvc.perform(post(BASE_URL + URL, voteId)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"likey","lik", "dis", "disLik"})
+        void 유효한_평가_타입이_아닌_경우_400_응답(final String voteEvaluationType) throws Exception{
+
+            // given
+            final Long voteId = 1L;
+            mockingForAuthorization();
+            final VoteEvaluateRequest voteEvaluateRequest = new VoteEvaluateRequest(voteEvaluationType);
+
+            // when & then
+            mockMvc.perform(post(BASE_URL + URL, voteId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                            .content(createJson(voteEvaluateRequest))
                             .characterEncoding(StandardCharsets.UTF_8)
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest());


### PR DESCRIPTION
# 📌 연관 이슈

- #26 

# 🧑‍💻 작업 내역

- [x] 투표 평가 기능 구현
- [x] 단위 테스트
- [x] API 문서화

### 예외 처리
- 투표 타입이 다를 경우
- 중복 투표가 발생했을 경우
- 평가할 투표가 존재하지 않는 경우

# 🧐 더 나아가야할 점 혹은 고민 : 예외 처리는 어느 계층에서해야할까?

투표 타입(LIKE, DISLIKE 등)이 다를 경우 예외처리를 해야한다.

그렇다면 예외 처리는 어느 계층에서 해야할까?

## 첫번째 : 도메인 계층에서 처리한다. ( Controller -> Service -> `Domain`  )

`VoteEvaluation` 을 생성할 때 매개변수로 투표 타입을 단순하게 String 타입으로 받아서 `VoteEvaluationType` 정적 팩토리 메서드를 통해 생성할 때 검증하는 방식이다.

```
    private VoteEvaluation(final Vote vote, final Member member, final String voteEvaluationType) {
        this.vote = vote;
        this.evaluator = member;
        this.voteEvaluationType = VoteEvaluationType.of(voteEvaluationType);
    }

    public static VoteEvaluation of(final Vote vote, final Member member, final String voteEvaluationType) {
        return new VoteEvaluation(vote, member, voteEvaluationType);
    }
```

### 장점

- 가장 깔끔하다.
- 안정적이다.

### 단점

`Application Layer` 를 거쳐서 들어오기 때문에 `DB Connection` 을 획득한다. 

### 정리

투표 타입이 다르면 애초에 `DB Connection` 을 획득하기 전에 예외처리를 해주는 것이 한정된 `DB Connection 자원`을 효율적으로 사용하여 불필요한 병목을 줄이는데 좋을 것이다.

## 두번째 : 표현계층에서 처리한다. (by Bean Validation + `@JsonCreator` ) 

```

public enum VoteEvaluationType {
    LIKE,
    DISLIKE;

    @JsonCreator
    public static VoteEvaluationType from(final String voteEvaluationType){
        return Arrays.stream(VoteEvaluationType.values())
                .filter(it -> it.name().equalsIgnoreCase(voteEvaluationType))
                .findFirst()
                .orElse(null);
    }
}


@Getter
@NoArgsConstructor(access = AccessLevel.PRIVATE)
public class VoteEvaluateRequest {

    @NotNull(message = "투표 타입을 입력해주세요(like, disLike)")
    private VoteEvaluationType voteEvaluationType;
    public VoteEvaluateRequest(final String voteEvaluationType){
        this.voteEvaluationType = VoteEvaluationType.from(voteEvaluationType);
    }
}

```

String 타입으로 요청을 받고 Enum 타입으로 `pasing`을 할 때, 미리 정의해놓은 타입이 아닌 경우 `null`로 반환하게 하여 `Bean Validation` 의 `@NotNull` 을 통해 `BindException` 을 발생시키고 `ControllerAdvice`의 `ExceptionHandler` 로 잡아 예외처리를 해주는 방식이다.

### 장점

- 불필요한 `DB Connection` 을 획득하지 않는다.

### 단점

- 불안전하다.

### 정리

이 구조는  도메인 계층이 표현계층을 의존하는 꼴이다.  만약 ReqeustDTO 를 누군가 고치게 되고 `Bean Validation` 의 `@NotNull` 을 제거하게 된다면...? 그대로 `null` 값이 DB 에 영속화될 것이다. 즉, 불안전하다. 물론 혹자는 예외 처리를 한번더하면 되지 않냐라고 반문할 수 있는데, 이러면 나중에 유지보수할 때 한 지점이 아닌 두 지점을 모두 수정해야 원활하게 동작하기에 피곤해진다.

## 세번째 : 표현계층에서 처리한다. (by Controller + VO의 정적 팩토리 메서드)

Request DTO는 단순하게 String 타입으로 받고 파싱해서, Controller 에서 VO의 정적 팩토리 메서드를 통해 생성하게 하는 방식이다. 

```

@Getter
@NoArgsConstructor(access = AccessLevel.PRIVATE)
public class VoteEvaluateRequest {

    @NotNull(message = "투표 타입을 입력해주세요")
    private String voteEvaluationType;
    public VoteEvaluateRequest(final String voteEvaluationType){
        this.voteEvaluationType = voteEvaluationType;
    }
}

    @PostMapping("/{vote-id}/evaluations")
    @ResponseStatus(HttpStatus.CREATED)
    @Login
    public void evaluateVote(@LoginMember MemberPayLoad memberPayLoad,
                             @PathVariable(name = "vote-id") final Long voteId,
                             @RequestBody @Valid final VoteEvaluateRequest voteEvaluateRequest){
        final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluateRequest.getVoteEvaluationType());
        voteService.evaluate(memberPayLoad, voteId, voteEvaluationType);
    }

public enum VoteEvaluationType {
    LIKE,
    DISLIKE;

    public static VoteEvaluationType from(final String voteEvaluationType){
        return Arrays.stream(VoteEvaluationType.values())
                .filter(it -> it.name().equalsIgnoreCase(voteEvaluationType))
                .findAny()
                .orElseThrow(() -> new VoteException(VoteExceptionType.INVALID_VOTE_EVALUATION_TYPE));
    }
}

```

### 장점

- 불필요한 `DB Connection` 을 획득하지 않는다.
- 깔끔하다.
- 안정적이다.

### 단점

- 아직까지는 모르겠음


## 결론

세번째 방식을 채택했다. 아직까지 내가 알고있는 지식 기반에서는 이게 최선의 선택이라고 생각하기 때문이다.