### PR TITLE
feat: 투표 페이징 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -234,3 +234,28 @@ include::{snippets}/투표_조회/투표_조회_성공/response-fields.adoc[]
 include::{snippets}/투표_조회/투표_조회_성공/http-request.adoc[]
 ===== 응답
 include::{snippets}/투표_조회/투표_조회_성공/http-response.adoc[]
+
+
+---
+
+
+=== 📌 투표 목록 조회
+==== 기본정보
+- 메서드 : GET
+- URL : `/api/votes`
+
+==== 요청
+===== 헤더
+include::{snippets}/투표_목록_조회/투표_조회_성공/request-headers.adoc[]
+===== 쿼리 변수
+include::{snippets}/투표_목록_조회/투표_조회_성공/request-parameters.adoc[]
+==== 응답
+===== 본문
+include::{snippets}/투표_목록_조회/투표_조회_성공/response-fields.adoc[]
+===== votes
+include::{snippets}/투표_목록_조회/투표_조회_성공/response-fields-votes.adoc[]
+==== 예시
+===== 요청
+include::{snippets}/투표_목록_조회/투표_조회_성공/http-request.adoc[]
+===== 응답
+include::{snippets}/투표_목록_조회/투표_조회_성공/http-response.adoc[]

--- a/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
+++ b/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
@@ -17,10 +17,13 @@ import com.salmalteam.salmal.domain.vote.report.VoteReportRepository;
 import com.salmalteam.salmal.dto.request.vote.VoteBookmarkRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteCommentCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteCreateRequest;
+import com.salmalteam.salmal.dto.request.vote.VotePageRequest;
+import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
 import com.salmalteam.salmal.exception.vote.VoteException;
 import com.salmalteam.salmal.exception.vote.VoteExceptionType;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
+import com.salmalteam.salmal.presentation.vote.SearchTypeConstant;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -173,6 +176,13 @@ public class VoteService {
     private Vote getVoteById(final Long voteId){
         return voteRepository.findById(voteId)
                 .orElseThrow(() -> new VoteException(VoteExceptionType.NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public VotePageResponse searchList(final MemberPayLoad memberPayLoad, final VotePageRequest votePageRequest, final SearchTypeConstant searchTypeConstant){
+
+        final Long memberId = memberPayLoad.getId();
+        return voteRepository.searchList(memberId, votePageRequest, searchTypeConstant);
     }
 
 

--- a/src/main/java/com/salmalteam/salmal/domain/vote/VoteRepositoryCustom.java
+++ b/src/main/java/com/salmalteam/salmal/domain/vote/VoteRepositoryCustom.java
@@ -1,8 +1,12 @@
 package com.salmalteam.salmal.domain.vote;
 
+import com.salmalteam.salmal.dto.request.vote.VotePageRequest;
+import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
+import com.salmalteam.salmal.presentation.vote.SearchTypeConstant;
 
 public interface VoteRepositoryCustom {
 
     VoteResponse search(final Long id, final Long memberId);
+    VotePageResponse searchList(final Long memberId, final VotePageRequest votePageRequest, final SearchTypeConstant searchTypeConstant);
 }

--- a/src/main/java/com/salmalteam/salmal/domain/vote/VoteRepositoryCustomImpl.java
+++ b/src/main/java/com/salmalteam/salmal/domain/vote/VoteRepositoryCustomImpl.java
@@ -1,12 +1,20 @@
 package com.salmalteam.salmal.domain.vote;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.salmalteam.salmal.dto.request.vote.VotePageRequest;
 import com.salmalteam.salmal.dto.response.vote.QVoteResponse;
+import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
+import com.salmalteam.salmal.presentation.vote.SearchTypeConstant;
 import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.salmalteam.salmal.domain.vote.QVote.vote;
 import static com.salmalteam.salmal.domain.vote.bookmark.QVoteBookMark.voteBookMark;
@@ -20,21 +28,8 @@ public class VoteRepositoryCustomImpl implements VoteRepositoryCustom {
     @Override
     public VoteResponse search(final Long id, final Long memberId) {
 
-        final BooleanExpression bookmarkSubQuery = JPAExpressions.selectFrom(voteBookMark)
-                .where(
-                        voteBookMark.vote.id.eq(id),
-                        voteBookMark.bookmaker.id.eq(memberId)
-                )
-                .exists();
-
-        final JPQLQuery<String> voteEvaluationSubQuery = JPAExpressions.select(
-                        voteEvaluation.voteEvaluationType.stringValue()
-                )
-                .where(
-                        voteEvaluation.vote.id.eq(id),
-                        voteEvaluation.evaluator.id.eq(memberId)
-                )
-                .from(voteEvaluation);
+        final BooleanExpression bookmarkSubQuery = createBookmarkSubQuery(id, memberId);
+        final JPQLQuery<String> voteEvaluationSubQuery = createVoteEvaluationSubQuery(id, memberId);
 
         return queryFactory.select(new QVoteResponse(
                         vote.id,
@@ -55,4 +50,108 @@ public class VoteRepositoryCustomImpl implements VoteRepositoryCustom {
                 .where(vote.id.eq(id))
                 .fetchOne();
     }
+
+    private BooleanExpression createBookmarkSubQuery(final Long id, final Long memberId) {
+        return JPAExpressions.selectFrom(voteBookMark)
+                .where(
+                        voteBookMark.vote.id.eq(id),
+                        voteBookMark.bookmaker.id.eq(memberId)
+                )
+                .exists();
+    }
+
+    private JPQLQuery<String> createVoteEvaluationSubQuery(final Long id,final Long memberId) {
+        return JPAExpressions.select(
+                        voteEvaluation.voteEvaluationType.stringValue()
+                )
+                .where(
+                        voteEvaluation.vote.id.eq(id),
+                        voteEvaluation.evaluator.id.eq(memberId)
+                )
+                .from(voteEvaluation);
+    }
+
+    /**
+     * TODO
+     * BEST : 내가 차단한 사람 조회 필터링
+     * HOME : 랜덤 조회
+     */
+    @Override
+    public VotePageResponse searchList(final Long memberId, final VotePageRequest votePageRequest, final SearchTypeConstant searchTypeConstant) {
+
+        // BEST : 좋아요 기준 내림차순 조회
+        // HOME : 랜덤 조회
+        final List<VoteResponse> voteResponses = queryFactory.select(new QVoteResponse(
+                        vote.id,
+                        vote.member.id,
+                        vote.voteImage.imageUrl,
+                        vote.member.nickName.value,
+                        vote.member.memberImage.imageUrl,
+                        vote.commentCount,
+                        vote.likeCount,
+                        vote.dislikeCount,
+                        vote.evaluationCount,
+                        vote.likeRatio,
+                        vote.dislikeRatio,
+                        vote.createdAt,
+                        voteBookMark.isBookmarked,
+                        voteEvaluation.voteEvaluationType.stringValue()))
+                .from(vote)
+                .leftJoin(voteEvaluation)
+                .on(vote.id.eq(voteEvaluation.vote.id).and(voteEvaluation.evaluator.id.eq(memberId)))
+                .leftJoin(voteBookMark)
+                .on(vote.id.eq(voteBookMark.id).and(voteBookMark.bookmaker.id.eq(memberId)))
+                .where(
+                        cursorLikeCountAndCursorId(votePageRequest.getCursorId(), votePageRequest.getCursorLikes())
+                )
+                .orderBy(orderSpecifiers(searchTypeConstant))
+                .limit(votePageRequest.getSize() + 1)
+                .fetch();
+
+        final boolean hasNext = isHasNext(voteResponses, votePageRequest.getSize());
+        return VotePageResponse.of(hasNext, voteResponses);
+    }
+
+    private boolean isHasNext(List<?> result,final int pageSize){
+        boolean hasNext = false;
+        if (result.size() > pageSize) {
+            hasNext = true;
+            result.remove(pageSize);
+        }
+        return hasNext;
+    }
+
+    private BooleanExpression cursorLikeCountAndCursorId(final Long cursorId, final Integer cursorLikeCount){
+        if(cursorLikeCount == null || cursorId == null) return null;
+
+        return vote.likeCount.eq(cursorLikeCount)
+                .and(vote.id.lt(cursorId))
+                .or(vote.likeCount.loe(cursorLikeCount));
+    }
+
+    private BooleanExpression ltLikeCount(final Integer cursorLikeCount){
+        return cursorLikeCount == null ? null : vote.likeCount.loe(cursorLikeCount);
+    }
+
+    private BooleanExpression ltId(final Long id){
+        return id == null ? null : vote.id.lt(id);
+    }
+
+    private OrderSpecifier[] orderSpecifiers(final SearchTypeConstant searchTypeConstant){
+        final List<OrderSpecifier> orderSpecifierList = new ArrayList<>();
+
+        switch(searchTypeConstant){
+            case BEST:
+                orderSpecifierList.add(new OrderSpecifier(Order.DESC, vote.likeCount));
+                orderSpecifierList.add(new OrderSpecifier(Order.DESC, vote.id));
+                break;
+
+            case HOME:
+                orderSpecifierList.add(new OrderSpecifier(Order.DESC, vote.id));
+                break;
+        }
+
+        return orderSpecifierList.toArray(new OrderSpecifier[orderSpecifierList.size()]);
+    }
+
 }

--- a/src/main/java/com/salmalteam/salmal/domain/vote/VoteRepositoryCustomImpl.java
+++ b/src/main/java/com/salmalteam/salmal/domain/vote/VoteRepositoryCustomImpl.java
@@ -128,15 +128,6 @@ public class VoteRepositoryCustomImpl implements VoteRepositoryCustom {
                 .and(vote.id.lt(cursorId))
                 .or(vote.likeCount.loe(cursorLikeCount));
     }
-
-    private BooleanExpression ltLikeCount(final Integer cursorLikeCount){
-        return cursorLikeCount == null ? null : vote.likeCount.loe(cursorLikeCount);
-    }
-
-    private BooleanExpression ltId(final Long id){
-        return id == null ? null : vote.id.lt(id);
-    }
-
     private OrderSpecifier[] orderSpecifiers(final SearchTypeConstant searchTypeConstant){
         final List<OrderSpecifier> orderSpecifierList = new ArrayList<>();
 

--- a/src/main/java/com/salmalteam/salmal/dto/request/vote/VotePageRequest.java
+++ b/src/main/java/com/salmalteam/salmal/dto/request/vote/VotePageRequest.java
@@ -1,0 +1,24 @@
+package com.salmalteam.salmal.dto.request.vote;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class VotePageRequest {
+
+    private final int DEFAULT_SIZE = 8;
+
+    private Long cursorId;
+    private Integer cursorLikes;
+    private Integer size;
+    private String searchType;
+
+    public VotePageRequest(final Long cursorId, final Integer cursorLikes, final Integer size, final String searchType) {
+        this.cursorId = cursorId;
+        this.cursorLikes = cursorLikes;
+        this.size = size == null ? DEFAULT_SIZE : size;
+        this.searchType = searchType;
+    }
+}

--- a/src/main/java/com/salmalteam/salmal/dto/response/vote/VotePageResponse.java
+++ b/src/main/java/com/salmalteam/salmal/dto/response/vote/VotePageResponse.java
@@ -1,0 +1,24 @@
+package com.salmalteam.salmal.dto.response.vote;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class VotePageResponse {
+
+    private boolean hasNext;
+    private List<VoteResponse> votes;
+
+    private VotePageResponse(final boolean hasNext,final List<VoteResponse> voteResponses) {
+        this.hasNext = hasNext;
+        this.votes = voteResponses;
+    }
+    public static VotePageResponse of(final boolean hasNext, final List<VoteResponse> voteResponses){
+        return new VotePageResponse(hasNext, voteResponses);
+    }
+
+}

--- a/src/main/java/com/salmalteam/salmal/exception/vote/VoteExceptionType.java
+++ b/src/main/java/com/salmalteam/salmal/exception/vote/VoteExceptionType.java
@@ -9,7 +9,8 @@ public enum VoteExceptionType implements ExceptionType {
     FORBIDDEN_UPDATE(Status.FORBIDDEN, 3003, "투표를 수정할 권한이 없습니다.", "권한이 없는 투표 수정 요청"),
     DUPLICATED_VOTE_EVALUATION(Status.BAD_REQUEST, 3004, "이미 평가를 한 투표입니다.", "중복된 투표 평가 요청"),
     INVALID_VOTE_EVALUATION_TYPE(Status.BAD_REQUEST, 3005, "투표타입은 LIKE 또는 DISLIKE 입니다.", "적절하지 않은 투표 타입 요청"),
-    DUPLICATED_VOTE_REPORT(Status.BAD_REQUEST, 3006, "이미 신고한 투표입니다.", "중복 투표 신고 요청")
+    DUPLICATED_VOTE_REPORT(Status.BAD_REQUEST, 3006, "이미 신고한 투표입니다.", "중복 투표 신고 요청"),
+    INVALID_VOTE_SEARCH_TYPE(Status.BAD_REQUEST, 3007, "잘못된 투표 검색 타입입니다. (BEST, HOME)", "잘못된 투표 검색 타입 요청")
     ;
 
     private final Status status;

--- a/src/main/java/com/salmalteam/salmal/presentation/vote/SearchTypeConstant.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/vote/SearchTypeConstant.java
@@ -1,0 +1,17 @@
+package com.salmalteam.salmal.presentation.vote;
+
+import com.salmalteam.salmal.exception.vote.VoteException;
+import com.salmalteam.salmal.exception.vote.VoteExceptionType;
+
+import java.util.Arrays;
+
+public enum SearchTypeConstant {
+    BEST,
+    HOME;
+    public static SearchTypeConstant from(final String searchType){
+        return Arrays.stream(values())
+                .filter(it -> it.name().equalsIgnoreCase(searchType))
+                .findAny()
+                .orElseThrow(() -> new VoteException(VoteExceptionType.INVALID_VOTE_SEARCH_TYPE));
+    }
+}

--- a/src/main/java/com/salmalteam/salmal/presentation/vote/VoteController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/vote/VoteController.java
@@ -3,11 +3,13 @@ package com.salmalteam.salmal.presentation.vote;
 import com.salmalteam.salmal.application.vote.VoteService;
 import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
 import com.salmalteam.salmal.dto.request.vote.*;
+import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 import com.salmalteam.salmal.presentation.Login;
 import com.salmalteam.salmal.presentation.LoginMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -69,6 +71,16 @@ public class VoteController {
     public VoteResponse searchVote(@LoginMember final MemberPayLoad memberPayLoad,
                                    @PathVariable(name = "vote-id") final Long voteId){
         return voteService.search(memberPayLoad, voteId);
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    @Login
+    public VotePageResponse searchVotes(@LoginMember final MemberPayLoad memberPayLoad,
+                                        @ModelAttribute final VotePageRequest votePageRequest){
+
+        final SearchTypeConstant searchTypeConstant = SearchTypeConstant.from(votePageRequest.getSearchType());
+        return voteService.searchList(memberPayLoad, votePageRequest, searchTypeConstant);
     }
 
 }

--- a/src/test/java/com/salmalteam/salmal/domain/vote/VoteRepositoryTest.java
+++ b/src/test/java/com/salmalteam/salmal/domain/vote/VoteRepositoryTest.java
@@ -8,7 +8,10 @@ import com.salmalteam.salmal.domain.vote.bookmark.VoteBookMarkRepository;
 import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluation;
 import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationRepository;
 import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
+import com.salmalteam.salmal.dto.request.vote.VotePageRequest;
+import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
+import com.salmalteam.salmal.presentation.vote.SearchTypeConstant;
 import com.salmalteam.salmal.support.RepositoryTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -18,6 +21,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import javax.persistence.EntityManager;
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -99,6 +103,83 @@ class VoteRepositoryTest extends RepositoryTest {
                     () -> assertThat(findVote.getLikeCount()).isEqualTo(2),
                     () -> assertThat(findVote.getLikeRatio()).isEqualTo(BigDecimal.valueOf(0.67)),
                     () -> assertThat(findVote.getDislikeRatio()).isEqualTo(BigDecimal.valueOf(0.33))
+            );
+        }
+    }
+
+    @Nested
+    class 투표_목록_조회_테스트{
+
+        @Test
+        @DirtiesContext
+        void 좋아요_평가_목록_조회_테스트(){
+            // given
+            final Long memberId = 1L;
+            final Member memberA = Member.of("pro1", "닉네임1", "kakao", true);
+            final Member memberB = Member.of("pro2", "닉네임2", "kakao", true);
+            final Member memberC = Member.of("pro3", "닉네임3", "kakao", true);
+
+            final Vote voteA = Vote.of("imageUrl", memberA);
+            final Vote voteB = Vote.of("imageUrl", memberA);
+            final Vote voteC = Vote.of("imageUrl", memberA);
+            final Vote voteD = Vote.of("imageUrl", memberA);
+            VoteEvaluation voteEvaluationA = VoteEvaluation.of(voteA, memberA, VoteEvaluationType.LIKE);
+            VoteEvaluation voteEvaluationB = VoteEvaluation.of(voteB, memberA, VoteEvaluationType.LIKE);
+            VoteEvaluation voteEvaluationC = VoteEvaluation.of(voteC, memberA, VoteEvaluationType.LIKE);
+            VoteEvaluation voteEvaluationD = VoteEvaluation.of(voteD, memberA, VoteEvaluationType.LIKE);
+
+            VoteEvaluation voteEvaluationF = VoteEvaluation.of(voteB, memberB, VoteEvaluationType.LIKE);
+            VoteEvaluation voteEvaluationG = VoteEvaluation.of(voteC, memberB, VoteEvaluationType.LIKE);
+            VoteEvaluation voteEvaluationH = VoteEvaluation.of(voteD, memberB, VoteEvaluationType.LIKE);
+
+            VoteEvaluation voteEvaluationI = VoteEvaluation.of(voteA, memberC, VoteEvaluationType.LIKE);
+            VoteEvaluation voteEvaluationJ = VoteEvaluation.of(voteB, memberC, VoteEvaluationType.LIKE);
+            VoteEvaluation voteEvaluationK = VoteEvaluation.of(voteC, memberC, VoteEvaluationType.LIKE);
+            VoteEvaluation voteEvaluationL = VoteEvaluation.of(voteD, memberC, VoteEvaluationType.LIKE);
+
+            final VotePageRequest votePageRequest = new VotePageRequest(3L, 3, 3, "BEST");
+
+            memberRepository.save(memberA);
+            memberRepository.save(memberB);
+            memberRepository.save(memberC);
+            voteRepository.save(voteA);
+            voteRepository.save(voteB);
+            voteRepository.save(voteC);
+            voteRepository.save(voteD);
+            voteEvaluationRepository.save(voteEvaluationA);
+            voteEvaluationRepository.save(voteEvaluationB);
+            voteEvaluationRepository.save(voteEvaluationC);
+            voteEvaluationRepository.save(voteEvaluationD);
+            voteEvaluationRepository.save(voteEvaluationF);
+            voteEvaluationRepository.save(voteEvaluationG);
+            voteEvaluationRepository.save(voteEvaluationH);
+            voteEvaluationRepository.save(voteEvaluationI);
+            voteEvaluationRepository.save(voteEvaluationJ);
+            voteEvaluationRepository.save(voteEvaluationK);
+            voteEvaluationRepository.save(voteEvaluationL);
+
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(1L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(1L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(2L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(2L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(3L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(3L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(3L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(4L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(4L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(4L);
+
+            // when
+            final VotePageResponse votePageResponse = voteRepository.searchList(memberId, votePageRequest, SearchTypeConstant.BEST);
+
+            // then
+            System.out.println(votePageResponse.isHasNext());
+            System.out.println(votePageResponse.getVotes().size());
+            List<VoteResponse> votes = votePageResponse.getVotes();
+            Assertions.assertAll(
+                    () -> assertThat(votes.size()).isEqualTo(3),
+                    () -> assertThat(votes.get(0).getLikeCount()).isEqualTo(3),
+                    () -> assertThat(votes.get(2).getLikeCount()).isEqualTo(2)
             );
         }
     }

--- a/src/test/java/com/salmalteam/salmal/presentation/vote/VoteControllerTest.java
+++ b/src/test/java/com/salmalteam/salmal/presentation/vote/VoteControllerTest.java
@@ -3,6 +3,8 @@ package com.salmalteam.salmal.presentation.vote;
 import com.salmalteam.salmal.dto.request.vote.VoteBookmarkRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteCommentCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteEvaluateRequest;
+import com.salmalteam.salmal.dto.request.vote.VotePageRequest;
+import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 import com.salmalteam.salmal.support.PresentationTest;
@@ -21,7 +23,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.io.FileInputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,7 +46,7 @@ class VoteControllerTest extends PresentationTest {
     @Nested
     class 투표_등록_테스트 {
         @Test
-        void 투표_등록_성공() throws Exception{
+        void 투표_등록_성공() throws Exception {
             // given
             final String name = "imageFile";
             final String fileName = "testImage.jpg";
@@ -75,7 +79,7 @@ class VoteControllerTest extends PresentationTest {
         }
 
         @Test
-        void 미인증_사용자일_경우_401_응답() throws Exception{
+        void 미인증_사용자일_경우_401_응답() throws Exception {
 
             // when & then
             mockMvc.perform(multipart(BASE_URL)
@@ -85,7 +89,7 @@ class VoteControllerTest extends PresentationTest {
         }
 
         @Test
-        void 이미지_파일이_없는_경우_400_응답() throws Exception{
+        void 이미지_파일이_없는_경우_400_응답() throws Exception {
 
             mockingForAuthorization();
 
@@ -100,11 +104,12 @@ class VoteControllerTest extends PresentationTest {
     }
 
     @Nested
-    class 투표_평가_테스트{
+    class 투표_평가_테스트 {
 
         private final static String URL = "/{vote-id}/evaluations";
+
         @Test
-        void 투표_평가_성공() throws Exception{
+        void 투표_평가_성공() throws Exception {
             // given
             final Long voteId = 1L;
             final String voteEvaluationType = "LIKE";
@@ -113,7 +118,7 @@ class VoteControllerTest extends PresentationTest {
             mockingForAuthorization();
 
             // when
-            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL+URL, voteId)
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + URL, voteId)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                             .content(createJson(voteEvaluateRequest))
                             .characterEncoding(StandardCharsets.UTF_8)
@@ -138,7 +143,7 @@ class VoteControllerTest extends PresentationTest {
         }
 
         @Test
-        void 미인증_사용자일_경우_401_응답() throws Exception{
+        void 미인증_사용자일_경우_401_응답() throws Exception {
 
             // given
             final Long voteId = 1L;
@@ -151,8 +156,8 @@ class VoteControllerTest extends PresentationTest {
         }
 
         @ParameterizedTest
-        @CsvSource(value = {"likey","lik", "dis", "disLik"})
-        void 유효한_평가_타입이_아닌_경우_400_응답(final String voteEvaluationType) throws Exception{
+        @CsvSource(value = {"likey", "lik", "dis", "disLik"})
+        void 유효한_평가_타입이_아닌_경우_400_응답(final String voteEvaluationType) throws Exception {
 
             // given
             final Long voteId = 1L;
@@ -171,11 +176,12 @@ class VoteControllerTest extends PresentationTest {
     }
 
     @Nested
-    class 투표_북마크_테스트{
+    class 투표_북마크_테스트 {
 
         private final static String URL = "/{vote-id}/bookmarks";
+
         @Test
-        void 투표_북마킹_성공() throws Exception{
+        void 투표_북마킹_성공() throws Exception {
             // given
             final Long voteId = 1L;
             final Boolean isBookmarked = true;
@@ -183,7 +189,7 @@ class VoteControllerTest extends PresentationTest {
             mockingForAuthorization();
 
             // when
-            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL+URL, voteId)
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + URL, voteId)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                             .content(createJson(voteBookmarkRequest))
                             .characterEncoding(StandardCharsets.UTF_8)
@@ -203,12 +209,12 @@ class VoteControllerTest extends PresentationTest {
                     )
             ));
 
-            verify(voteService, times(1)).bookmark(any(), any(),any());
+            verify(voteService, times(1)).bookmark(any(), any(), any());
 
         }
 
         @Test
-        void 미인증_사용자일_경우_401_응답() throws Exception{
+        void 미인증_사용자일_경우_401_응답() throws Exception {
 
             // given
             final Long voteId = 1L;
@@ -221,7 +227,7 @@ class VoteControllerTest extends PresentationTest {
         }
 
         @Test
-        void 북마크_여부가_전달이_안된_경우_400_응답() throws Exception{
+        void 북마크_여부가_전달이_안된_경우_400_응답() throws Exception {
 
             // given
             final Long voteId = 1L;
@@ -241,17 +247,17 @@ class VoteControllerTest extends PresentationTest {
     }
 
     @Nested
-    class 투표_신고_테스트{
+    class 투표_신고_테스트 {
         private final static String URL = "/{vote-id}/reports";
 
         @Test
-        void 투표_신고_성공() throws Exception{
+        void 투표_신고_성공() throws Exception {
             // given
             final Long voteId = 1L;
             mockingForAuthorization();
 
             // when
-            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL+URL, voteId)
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + URL, voteId)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                             .characterEncoding(StandardCharsets.UTF_8)
                             .contentType(MediaType.APPLICATION_JSON))
@@ -272,7 +278,7 @@ class VoteControllerTest extends PresentationTest {
         }
 
         @Test
-        void 미인증_사용자일_경우_401_응답() throws Exception{
+        void 미인증_사용자일_경우_401_응답() throws Exception {
 
             // given
             final Long voteId = 1L;
@@ -286,10 +292,11 @@ class VoteControllerTest extends PresentationTest {
     }
 
     @Nested
-    class 투표_댓글_생성_테스트{
+    class 투표_댓글_생성_테스트 {
         private final static String URL = "/{vote-id}/comments";
+
         @Test
-        void 댓글_생성_성공() throws Exception{
+        void 댓글_생성_성공() throws Exception {
             // given
             final Long voteId = 1L;
             final String content = "이 옷 정말 멋져요!";
@@ -297,7 +304,7 @@ class VoteControllerTest extends PresentationTest {
             mockingForAuthorization();
 
             // when
-            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL+URL, voteId)
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + URL, voteId)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                             .content(createJson(voteCommentCreateRequest))
                             .characterEncoding(StandardCharsets.UTF_8)
@@ -317,11 +324,11 @@ class VoteControllerTest extends PresentationTest {
                     )
             ));
 
-            verify(voteService, times(1)).comment(any(),any(),any());
+            verify(voteService, times(1)).comment(any(), any(), any());
         }
 
         @Test
-        void 댓글을_입력하지_않은_경우_400응답() throws Exception{
+        void 댓글을_입력하지_않은_경우_400응답() throws Exception {
             // given
             final Long voteId = 1L;
             final String content = "";
@@ -329,7 +336,7 @@ class VoteControllerTest extends PresentationTest {
             mockingForAuthorization();
 
             // when & then
-            mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL+URL, voteId)
+            mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + URL, voteId)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                             .content(createJson(voteCommentCreateRequest))
                             .characterEncoding(StandardCharsets.UTF_8)
@@ -339,7 +346,7 @@ class VoteControllerTest extends PresentationTest {
         }
 
         @Test
-        void 미인증_사용자일_경우_401_응답() throws Exception{
+        void 미인증_사용자일_경우_401_응답() throws Exception {
 
             // given
             final Long voteId = 1L;
@@ -353,12 +360,12 @@ class VoteControllerTest extends PresentationTest {
     }
 
     @Nested
-    class 투표_조회{
+    class 투표_조회 {
 
         private final String URL = "/{vote-id}";
 
         @Test
-        void 투표_조회_성공() throws Exception{
+        void 투표_조회_성공() throws Exception {
             // given
             final Long voteId = 1L;
             final Long memberId = 1L;
@@ -368,7 +375,7 @@ class VoteControllerTest extends PresentationTest {
             mockingForAuthorization();
 
             // when
-            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL+URL, voteId)
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + URL, voteId)
                             .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                             .characterEncoding(StandardCharsets.UTF_8)
                             .contentType(MediaType.APPLICATION_JSON))
@@ -400,14 +407,93 @@ class VoteControllerTest extends PresentationTest {
                     )
             ));
         }
+
         @Test
-        void 미인증_사용자일_경우_401_응답() throws Exception{
+        void 미인증_사용자일_경우_401_응답() throws Exception {
 
             // given
             final Long voteId = 1L;
 
             // when & then
             mockMvc.perform(get(BASE_URL + URL, voteId)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    class 투표_목록_조회 {
+        @Test
+        void 투표_조회_성공() throws Exception {
+            // given
+            final Long cursorId = 1L;
+            final Integer cursorLikes = 3;
+            final Integer size = 8;
+            final String searchType = "BEST";
+            final String imageURL = "https://.../image.jpg";
+
+            final VoteResponse voteResponse1 = new VoteResponse(2L, 23L, imageURL, "사과", imageURL, 23, 50, 50, 100, BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.5), LocalDateTime.now(), true, "NONE");
+            final VoteResponse voteResponse2 = new VoteResponse(3L, 2L, imageURL, "포도", imageURL, 2, 20, 10, 30, BigDecimal.valueOf(0.67), BigDecimal.valueOf(0.33), LocalDateTime.now(), false, "LIKE");
+            final VoteResponse voteResponse3 = new VoteResponse(1L, 100L, imageURL, "옥수수", imageURL, 10, 10, 10, 20, BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.5), LocalDateTime.now(), true, "DISLIKE");
+
+            final VotePageResponse votePageResponse = VotePageResponse.of(true, List.of(voteResponse1, voteResponse2, voteResponse3));
+
+            given(voteService.searchList(any(), any(), any())).willReturn(votePageResponse);
+            mockingForAuthorization();
+
+            // when
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                            .param("cursorId", String.valueOf(cursorId))
+                            .param("cursorLikes", String.valueOf(cursorLikes))
+                            .param("size", String.valueOf(size))
+                            .param("searchType", searchType)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isOk());
+
+            // then
+            resultActions.andDo(restDocs.document(
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 타입 AccessToken")
+                    ),
+                    requestParameters(
+                            parameterWithName("cursorId").optional().description("이전 마지막 검색 결과 투표 ID (첫 페이지 조회 시 입력 X)"),
+                            parameterWithName("cursorLikes").optional().description("이전 마지막 검색 결과 좋아요 개수 (첫 페이지 조회 시 입력 X)"),
+                            parameterWithName("size").optional().description("검색할 ROW 수"),
+                            parameterWithName("searchType").description("검색 타입 (BEST, HOME)")
+                    ),
+                    responseFields(
+                            fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부 "),
+                            subsectionWithPath("votes").type(JsonFieldType.ARRAY).description("투표 목록")
+                    )
+            )).andDo(restDocs.document(
+                            responseFields(beneathPath("votes").withSubsectionId("votes"),
+                                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("투표 ID"),
+                                    fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("투표 작성자 ID"),
+                                    fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("투표 이미지 URL"),
+                                    fieldWithPath("nickName").type(JsonFieldType.STRING).description("투표 작성자 닉네임"),
+                                    fieldWithPath("memberImageUrl").type(JsonFieldType.STRING).description("투표 작성자 이미지 URL"),
+                                    fieldWithPath("commentCount").type(JsonFieldType.NUMBER).description("댓글 개수"),
+                                    fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                                    fieldWithPath("disLikeCount").type(JsonFieldType.NUMBER).description("싫어요 개수"),
+                                    fieldWithPath("totalEvaluationCnt").type(JsonFieldType.NUMBER).description("총 투표 개수"),
+                                    fieldWithPath("likeRatio").type(JsonFieldType.NUMBER).description("총 투표 개수"),
+                                    fieldWithPath("disLikeRatio").type(JsonFieldType.NUMBER).description("총 투표 개수"),
+                                    fieldWithPath("createdAt").type(JsonFieldType.STRING).description("투표 생성일"),
+                                    fieldWithPath("bookmarked").type(JsonFieldType.BOOLEAN).description("내가 북마크 했는지 여부 (true, false) "),
+                                    fieldWithPath("status").type(JsonFieldType.STRING).description("해당 투표에 대한 나의 상태 (NONE, LIKE, DISLIKE)")
+                            )
+                    )
+            );
+        }
+
+        @Test
+        void 미인증_사용자일_경우_401_응답() throws Exception {
+
+            // when & then
+            mockMvc.perform(get(BASE_URL)
                             .characterEncoding(StandardCharsets.UTF_8)
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isUnauthorized());


### PR DESCRIPTION
# 📌 연관 이슈

- #42

# 🧑‍💻 작업 내역

- [x] 투표 페이징 조회 기능 구현
- [x] 단위 테스트
- [x] API 문서화

# 🧐 더 나아가야할 점 혹은 고민

- [ ] `path-parameter` 예외 처리 더 깔끔하게 하는 방법 생각하고 예외 처리 방법 개선하기
- [ ] `메서드 명`, `변수 명` 적절하지 고민해보고 개선하기
- [ ] 추후 리팩토링 위해 테스트 코드 추가하기
- [ ] 중복 코드를 제거하기 위해 적절한 `Fixture` 도입하기
- [ ] 추후 통합 테스트 격리 방법 생각하고 도입하기
- [ ] 도메인 어느정도 정해지고 리팩토링 후 DB `INDEX` 적용하기