### PR TITLE
feat: 투표 댓글 목록 전체 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -299,6 +299,26 @@ include::{snippets}/투표_댓글_목록_조회_테스트/댓글_목록_조회_�
 ===== 응답
 include::{snippets}/투표_댓글_목록_조회_테스트/댓글_목록_조회_성공/http-response.adoc[]
 
+---
+
+=== 📌 투표 댓글 목록 전체 조회 ( 임시 )
+==== 기본정보
+- 메서드 : GET
+- URL : `/api/votes/{vote-id}/comments/all`
+
+==== 요청
+===== 헤더
+include::{snippets}/투표_댓글_목록_전체_조회_테스트/투표_댓글_목록_전체_조회_성공/request-headers.adoc[]
+===== 경로 변수
+include::{snippets}/투표_댓글_목록_전체_조회_테스트/투표_댓글_목록_전체_조회_성공/path-parameters.adoc[]
+==== 응답
+===== 본문
+include::{snippets}/투표_댓글_목록_전체_조회_테스트/투표_댓글_목록_전체_조회_성공/response-fields.adoc[]
+==== 예시
+===== 요청
+include::{snippets}/투표_댓글_목록_전체_조회_테스트/투표_댓글_목록_전체_조회_성공/http-request.adoc[]
+===== 응답
+include::{snippets}/투표_댓글_목록_전체_조회_테스트/투표_댓글_목록_전체_조회_성공/http-response.adoc[]
 
 == 댓글 API
 

--- a/src/main/java/com/salmalteam/salmal/application/comment/CommentService.java
+++ b/src/main/java/com/salmalteam/salmal/application/comment/CommentService.java
@@ -12,6 +12,7 @@ import com.salmalteam.salmal.domain.comment.CommentRepository;
 import com.salmalteam.salmal.dto.request.comment.CommentPageRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteCommentUpdateRequest;
 import com.salmalteam.salmal.dto.response.comment.CommentPageResponse;
+import com.salmalteam.salmal.dto.response.comment.CommentResponse;
 import com.salmalteam.salmal.exception.comment.CommentException;
 import com.salmalteam.salmal.exception.comment.CommentExceptionType;
 import com.salmalteam.salmal.exception.comment.like.CommentLikeException;
@@ -22,6 +23,8 @@ import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -63,6 +66,12 @@ public class CommentService {
                                           final CommentPageRequest commentPageRequest) {
         final Long memberId = memberPayLoad.getId();
         return commentRepository.searchList(voteId, memberId, commentPageRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> searchAllList(final Long voteId, final MemberPayLoad memberPayLoad){
+        final Long memberId = memberPayLoad.getId();
+        return commentRepository.searchAllList(voteId, memberId);
     }
 
     @Transactional

--- a/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
+++ b/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
@@ -19,6 +19,7 @@ import com.salmalteam.salmal.dto.request.vote.VoteCommentCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VotePageRequest;
 import com.salmalteam.salmal.dto.response.comment.CommentPageResponse;
+import com.salmalteam.salmal.dto.response.comment.CommentResponse;
 import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
 import com.salmalteam.salmal.exception.vote.VoteException;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -180,6 +182,12 @@ public class VoteService {
     public CommentPageResponse searchComments(final Long voteId, final MemberPayLoad memberPayLoad, final CommentPageRequest commentPageRequest){
         validateVoteExist(voteId);
         return commentService.searchList(voteId, memberPayLoad, commentPageRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> searchAllComments(final Long voteId, final MemberPayLoad memberPayLoad){
+        validateVoteExist(voteId);
+        return commentService.searchAllList(voteId, memberPayLoad);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/salmalteam/salmal/domain/comment/CommentRepositoryCustom.java
+++ b/src/main/java/com/salmalteam/salmal/domain/comment/CommentRepositoryCustom.java
@@ -2,7 +2,11 @@ package com.salmalteam.salmal.domain.comment;
 
 import com.salmalteam.salmal.dto.request.comment.CommentPageRequest;
 import com.salmalteam.salmal.dto.response.comment.CommentPageResponse;
+import com.salmalteam.salmal.dto.response.comment.CommentResponse;
+
+import java.util.List;
 
 public interface CommentRepositoryCustom {
     CommentPageResponse searchList(final Long voteId, final Long memberId, final CommentPageRequest commentPageRequest);
+    List<CommentResponse> searchAllList(final Long voteId, final Long memberId);
 }

--- a/src/main/java/com/salmalteam/salmal/domain/comment/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/salmalteam/salmal/domain/comment/CommentRepositoryCustomImpl.java
@@ -44,6 +44,32 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         return CommentPageResponse.of(hasNext, commentResponses);
     }
 
+    /**
+     * iOS 요청 (임시) 사항 : 댓글 전체 조회 기능
+     * 페이지네이션 적용 안함
+     */
+    @Override
+    public List<CommentResponse> searchAllList(final Long voteId, final Long memberId){
+
+        return jpaQueryFactory.select(new QCommentResponse(
+                        comment.id,
+                        comment.commenter.id,
+                        comment.commenter.memberImage.imageUrl,
+                        commentLike.isNotNull(),
+                        comment.likeCount,
+                        comment.content.value,
+                        comment.createAt,
+                        comment.updateAt))
+                .from(comment)
+                .leftJoin(commentLike)
+                .on(commentLike.comment.id.eq(comment.id).and(commentLike.liker.id.eq(memberId)))
+                .where(
+                        comment.vote.id.eq(voteId)
+                )
+                .orderBy(comment.id.desc())
+                .fetch();
+    }
+
     private boolean isHasNext(List<?> result, final int pageSize) {
         boolean hasNext = false;
         if (result.size() > pageSize) {

--- a/src/main/java/com/salmalteam/salmal/presentation/vote/VoteController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/vote/VoteController.java
@@ -5,6 +5,7 @@ import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluationType;
 import com.salmalteam.salmal.dto.request.comment.CommentPageRequest;
 import com.salmalteam.salmal.dto.request.vote.*;
 import com.salmalteam.salmal.dto.response.comment.CommentPageResponse;
+import com.salmalteam.salmal.dto.response.comment.CommentResponse;
 import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
@@ -16,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -91,6 +93,17 @@ public class VoteController {
                                               @RequestParam(value = "size", required = false) final Integer size){
         final CommentPageRequest commentPageRequest = CommentPageRequest.of(cursorId, size);
         return voteService.searchComments(voteId, memberPayLoad, commentPageRequest);
+    }
+
+    /**
+     * iOS 요청 사항 : 댓글 전체 목록 조회 API
+     */
+    @GetMapping("/{vote-id}/comments/all")
+    @ResponseStatus(HttpStatus.OK)
+    @Login
+    public List<CommentResponse> searchAllComments(@LoginMember final MemberPayLoad memberPayLoad,
+                                                   @PathVariable(name = "vote-id") final Long voteId){
+        return voteService.searchAllComments(voteId, memberPayLoad);
     }
 
     @GetMapping("/{vote-id}")

--- a/src/test/java/com/salmalteam/salmal/presentation/vote/VoteControllerTest.java
+++ b/src/test/java/com/salmalteam/salmal/presentation/vote/VoteControllerTest.java
@@ -597,6 +597,54 @@ class VoteControllerTest extends PresentationTest {
     }
 
     @Nested
+    class 투표_댓글_목록_전체_조회_테스트{
+
+        private final static String URL = "/{vote-id}/comments/all";
+
+        @Test
+        void 투표_댓글_목록_전체_조회_성공() throws Exception{
+            // given
+            final Long voteId = 1L;
+            final String memberImageURL = "https://.../image.jpg";
+            final CommentResponse commentResponse1 = new CommentResponse(5L, 1L, memberImageURL,false, 33, "이옷 정말 예뻐요~!", LocalDateTime.now(), LocalDateTime.now());
+            final CommentResponse commentResponse2 = new CommentResponse(4L, 2L,memberImageURL, false, 31, "강추 강추!", LocalDateTime.now(), LocalDateTime.now());
+            final CommentResponse commentResponse3 = new CommentResponse(3L, 3L,memberImageURL, false, 22, "좋네요", LocalDateTime.now(), LocalDateTime.now());
+
+            given(voteService.searchAllComments(any(), any())).willReturn(List.of(commentResponse1, commentResponse2, commentResponse3));
+
+            mockingForAuthorization();
+
+            // when
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + URL, voteId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isOk());
+
+            // then
+            resultActions.andDo(restDocs.document(
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 타입 AccessToken")
+                    ),
+                    pathParameters(
+                            parameterWithName("vote-id").description("댓글 전체 목록을 조회할 투표 ID")
+                    ),
+                    responseFields(
+                            subsectionWithPath("[].id").type(JsonFieldType.NUMBER).description("댓글 ID"),
+                            subsectionWithPath("[].memberId").type(JsonFieldType.NUMBER).description("댓글 작성자 ID"),
+                            subsectionWithPath("[].memberImageUrl").type(JsonFieldType.STRING).description("댓글 작성자 프로필 이미지 URL"),
+                            subsectionWithPath("[].liked").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
+                            subsectionWithPath("[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                            subsectionWithPath("[].content").type(JsonFieldType.STRING).description("댓글 내용"),
+                            subsectionWithPath("[].createdAt").type(JsonFieldType.STRING).description("댓글 생성일"),
+                            subsectionWithPath("[].updatedAt").type(JsonFieldType.STRING).description("댓글 수정일")
+                    )
+            ));
+
+        }
+    }
+
+    @Nested
     class 투표_평가_취소_테스트{
 
         private final static String URL = "/{vote-id}/evaluations";


### PR DESCRIPTION
# 📌 연관 이슈

- #86 

# 🧑‍💻 작업 내역

- [x] 투표 댓글 목록 전체 조회 기능 구현 
- [x] API 문서화

# 🧐 더 나아가야할 점 혹은 고민

해당 API 는 페이지네이션을 사용하지 않는다. 따라서 조회할 투표의 댓글의 양이 늘어나게 될 수록 조회 성능은 떨어지게 된다. 
추후에는 기존에 존재하는 커서 기반 페이지네이션 방식으로 조회하는 것이 합리적