### PR TITLE
feat: 대댓글 생성 기능 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -340,6 +340,23 @@ include::{snippets}/댓글_수정_테스트/댓글_수정_성공/http-request.ad
 ===== 응답
 include::{snippets}/댓글_수정_테스트/댓글_수정_성공/http-response.adoc[]
 
+---
+
+=== 대댓글 생성
+==== 기본정보
+- 메서드 : POST
+- URL : `/api/comments/{comment-id}/replys`
+
+==== 요청
+===== 헤더
+include::{snippets}/대댓글_생성_테스트/대댓글_생성_성공/request-headers.adoc[]
+===== 경로 변수
+include::{snippets}/대댓글_생성_테스트/대댓글_생성_성공/path-parameters.adoc[]
+==== 예시
+===== 요청
+include::{snippets}/대댓글_생성_테스트/대댓글_생성_성공/http-request.adoc[]
+===== 응답
+include::{snippets}/대댓글_생성_테스트/대댓글_생성_성공/http-response.adoc[]
 
 ---
 

--- a/src/main/java/com/salmalteam/salmal/application/comment/CommentService.java
+++ b/src/main/java/com/salmalteam/salmal/application/comment/CommentService.java
@@ -10,6 +10,7 @@ import com.salmalteam.salmal.domain.vote.Vote;
 import com.salmalteam.salmal.domain.comment.Comment;
 import com.salmalteam.salmal.domain.comment.CommentRepository;
 import com.salmalteam.salmal.dto.request.comment.CommentPageRequest;
+import com.salmalteam.salmal.dto.request.comment.CommentReplyCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteCommentUpdateRequest;
 import com.salmalteam.salmal.dto.response.comment.CommentPageResponse;
 import com.salmalteam.salmal.dto.response.comment.CommentResponse;
@@ -39,6 +40,18 @@ public class CommentService {
     public void save(final String content, final Vote vote, final Member member) {
         final Comment comment = Comment.of(content, vote, member);
         commentRepository.save(comment);
+    }
+
+    @Transactional
+    public void replyComment(final MemberPayLoad memberPayLoad, final Long commentId, final CommentReplyCreateRequest commentReplyCreateRequest){
+
+        final Member member = memberService.findMemberById(memberPayLoad.getId());
+
+        final Comment comment = getCommentById(commentId);
+        final Comment reply = Comment.ofReply(commentReplyCreateRequest.getContent(), comment, member);
+
+        commentRepository.save(reply);
+        commentRepository.increaseReplyCount(commentId);
     }
 
     @Transactional

--- a/src/main/java/com/salmalteam/salmal/domain/comment/Comment.java
+++ b/src/main/java/com/salmalteam/salmal/domain/comment/Comment.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -35,14 +37,40 @@ public class Comment extends BaseEntity {
     @Column
     private int likeCount = 0;
 
+    @Column
+    private int replyCount = 0;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private CommentType commentType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment")
+    private List<Comment> childComments = new ArrayList<>();
+
     private Comment(final String content, final Vote vote, final Member commenter){
         this.content = Content.of(content);
         this.commenter = commenter;
         this.vote = vote;
+        this.commentType = CommentType.COMMENT;
+    }
+
+    private Comment(final String content, final Comment parentComment, final Member replier){
+        this.content = Content.of(content);
+        this.commenter = replier;
+        this.parentComment = parentComment;
+        this.commentType =CommentType.REPLY;
     }
 
     public static Comment of(final String content, final Vote vote, final Member commenter){
         return new Comment(content, vote, commenter);
+    }
+
+    public static Comment ofReply(final String content, final Comment parentComment, final Member replier){
+        return new Comment(content, parentComment, replier);
     }
 
     public void updateContent(final String content){

--- a/src/main/java/com/salmalteam/salmal/domain/comment/CommentRepository.java
+++ b/src/main/java/com/salmalteam/salmal/domain/comment/CommentRepository.java
@@ -17,4 +17,8 @@ public interface CommentRepository extends Repository<Comment, Long>, CommentRep
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "update Comment c set c.likeCount = c.likeCount - 1 where c.id = :id")
     void decreaseLikeCount(Long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "update Comment c set c.replyCount = c.replyCount + 1 where c.id = :id")
+    void increaseReplyCount(Long id);
 }

--- a/src/main/java/com/salmalteam/salmal/domain/comment/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/salmalteam/salmal/domain/comment/CommentRepositoryCustomImpl.java
@@ -23,9 +23,11 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         final List<CommentResponse> commentResponses = jpaQueryFactory.select(new QCommentResponse(
                         comment.id,
                         comment.commenter.id,
+                        comment.commenter.nickName.value,
                         comment.commenter.memberImage.imageUrl,
                         commentLike.isNotNull(),
                         comment.likeCount,
+                        comment.replyCount,
                         comment.content.value,
                         comment.createAt,
                         comment.updateAt))
@@ -34,6 +36,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                 .on(commentLike.comment.id.eq(comment.id).and(commentLike.liker.id.eq(memberId)))
                 .where(
                         comment.vote.id.eq(voteId),
+                        comment.commentType.eq(CommentType.COMMENT),
                         cursorId(commentPageRequest.getCursorId())
                 )
                 .orderBy(comment.id.desc())
@@ -54,9 +57,11 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         return jpaQueryFactory.select(new QCommentResponse(
                         comment.id,
                         comment.commenter.id,
+                        comment.commenter.nickName.value,
                         comment.commenter.memberImage.imageUrl,
                         commentLike.isNotNull(),
                         comment.likeCount,
+                        comment.replyCount,
                         comment.content.value,
                         comment.createAt,
                         comment.updateAt))
@@ -64,10 +69,12 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                 .leftJoin(commentLike)
                 .on(commentLike.comment.id.eq(comment.id).and(commentLike.liker.id.eq(memberId)))
                 .where(
+                        comment.commentType.eq(CommentType.COMMENT),
                         comment.vote.id.eq(voteId)
                 )
                 .orderBy(comment.id.desc())
                 .fetch();
+
     }
 
     private boolean isHasNext(List<?> result, final int pageSize) {

--- a/src/main/java/com/salmalteam/salmal/domain/comment/CommentType.java
+++ b/src/main/java/com/salmalteam/salmal/domain/comment/CommentType.java
@@ -1,0 +1,5 @@
+package com.salmalteam.salmal.domain.comment;
+
+public enum CommentType {
+    COMMENT, REPLY
+}

--- a/src/main/java/com/salmalteam/salmal/dto/request/comment/CommentReplyCreateRequest.java
+++ b/src/main/java/com/salmalteam/salmal/dto/request/comment/CommentReplyCreateRequest.java
@@ -1,0 +1,19 @@
+package com.salmalteam.salmal.dto.request.comment;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentReplyCreateRequest {
+
+    @NotBlank(message = "댓글을 입력해주세요")
+    private String content;
+
+    public CommentReplyCreateRequest(final String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/salmalteam/salmal/dto/response/comment/CommentResponse.java
+++ b/src/main/java/com/salmalteam/salmal/dto/response/comment/CommentResponse.java
@@ -10,19 +10,23 @@ public class CommentResponse {
 
     private Long id;
     private Long memberId;
+    private String nickName;
     private String memberImageUrl;
     private boolean liked;
     private int likeCount;
+    private int replyCount;
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     @QueryProjection
-    public CommentResponse(Long id, Long memberId, String memberImageUrl, boolean liked, int likeCount, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public CommentResponse(Long id, Long memberId, String nickName, String memberImageUrl, boolean liked, int likeCount, int replyCount, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.memberId = memberId;
+        this.nickName = nickName;
         this.memberImageUrl = memberImageUrl;
         this.liked = liked;
         this.likeCount = likeCount;
+        this.replyCount = replyCount;
         this.content = content;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/src/main/java/com/salmalteam/salmal/presentation/comment/CommentController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/comment/CommentController.java
@@ -2,6 +2,7 @@ package com.salmalteam.salmal.presentation.comment;
 
 import com.salmalteam.salmal.application.comment.CommentService;
 import com.salmalteam.salmal.dto.request.comment.CommentPageRequest;
+import com.salmalteam.salmal.dto.request.comment.CommentReplyCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteCommentUpdateRequest;
 import com.salmalteam.salmal.dto.response.comment.CommentPageResponse;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
@@ -49,6 +50,15 @@ public class CommentController {
     public void reportComment(@LoginMember final MemberPayLoad memberPayLoad,
                               @PathVariable(name = "comment-id") final Long commentId){
         commentService.report(memberPayLoad, commentId);
+    }
+
+    @PostMapping("/{comment-id}/replys")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Login
+    public void replyComment(@LoginMember final MemberPayLoad memberPayLoad,
+                             @PathVariable(name = "comment-id") final Long commentId,
+                             @RequestBody @Valid CommentReplyCreateRequest commentReplyCreateRequest){
+        commentService.replyComment(memberPayLoad, commentId, commentReplyCreateRequest);
     }
 
 

--- a/src/test/java/com/salmalteam/salmal/presentation/comment/CommentControllerTest.java
+++ b/src/test/java/com/salmalteam/salmal/presentation/comment/CommentControllerTest.java
@@ -1,5 +1,6 @@
 package com.salmalteam.salmal.presentation.comment;
 
+import com.salmalteam.salmal.dto.request.comment.CommentReplyCreateRequest;
 import com.salmalteam.salmal.dto.request.vote.VoteCommentUpdateRequest;
 import com.salmalteam.salmal.support.PresentationTest;
 import org.junit.jupiter.api.Nested;
@@ -203,7 +204,46 @@ class CommentControllerTest extends PresentationTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isUnauthorized());
         }
-
-
     }
+
+    @Nested
+    class 대댓글_생성_테스트{
+        private final String URL = "/replys";
+
+        @Test
+        void 대댓글_생성_성공() throws Exception{
+            // given
+            final Long commentId = 1L;
+            final String content = "이 댓글에 동의합니다!";
+            final CommentReplyCreateRequest commentReplyCreateRequest = new CommentReplyCreateRequest(content);
+
+            mockingForAuthorization();
+
+            // when
+            final ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + URL, commentId)
+                            .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                            .content(createJson(commentReplyCreateRequest))
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(MockMvcResultMatchers.status().isCreated());
+
+            // then
+            resultActions.andDo(restDocs.document(
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 타입 AccessToken")
+                    ),
+                    pathParameters(
+                            parameterWithName("comment-id").description("대댓글을 추가할 댓글 ID")
+                    ),
+                    requestFields(
+                            fieldWithPath("content").type(JsonFieldType.STRING).description("댓글 내용 ( 최소 1글자 ~ 최대 100글자 ) ")
+                    )
+            ));
+
+            verify(commentService, times(1)).replyComment(any(), any(), any());
+
+        }
+    }
+
+
 }

--- a/src/test/java/com/salmalteam/salmal/presentation/vote/VoteControllerTest.java
+++ b/src/test/java/com/salmalteam/salmal/presentation/vote/VoteControllerTest.java
@@ -533,9 +533,9 @@ class VoteControllerTest extends PresentationTest {
             final Long cursorId = 6L;
             final int size = 3;
             final String memberImageURL = "https://.../image.jpg";
-            final CommentResponse commentResponse1 = new CommentResponse(5L, 1L, memberImageURL,false, 33, "이옷 정말 예뻐요~!", LocalDateTime.now(), LocalDateTime.now());
-            final CommentResponse commentResponse2 = new CommentResponse(4L, 2L,memberImageURL, false, 31, "강추 강추!", LocalDateTime.now(), LocalDateTime.now());
-            final CommentResponse commentResponse3 = new CommentResponse(3L, 3L,memberImageURL, false, 22, "좋네요", LocalDateTime.now(), LocalDateTime.now());
+            final CommentResponse commentResponse1 = new CommentResponse(5L, 1L,"사과나무", memberImageURL,false, 33, 3, "이옷 정말 예뻐요~!", LocalDateTime.now(), LocalDateTime.now());
+            final CommentResponse commentResponse2 = new CommentResponse(4L, 2L,"느티나무",memberImageURL, false, 31, 10, "강추 강추!", LocalDateTime.now(), LocalDateTime.now());
+            final CommentResponse commentResponse3 = new CommentResponse(3L, 3L,"포도나무",memberImageURL, false, 22, 1,"좋네요", LocalDateTime.now(), LocalDateTime.now());
 
             final CommentPageResponse commentPageResponse = CommentPageResponse.of(true, List.of(commentResponse1, commentResponse2, commentResponse3));
             given(voteService.searchComments(any(), any(), any())).willReturn(commentPageResponse);
@@ -571,9 +571,11 @@ class VoteControllerTest extends PresentationTest {
                             responseFields(beneathPath("comments").withSubsectionId("comments"),
                                     fieldWithPath("id").type(JsonFieldType.NUMBER).description("댓글 ID"),
                                     fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("댓글 작성자 ID "),
+                                    fieldWithPath("nickName").type(JsonFieldType.STRING).description("작성자 닉네임"),
                                     fieldWithPath("memberImageUrl").type(JsonFieldType.STRING).description("댓글 작성자 프로필 이미지 URL"),
                                     fieldWithPath("liked").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
                                     fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                                    fieldWithPath("replyCount").type(JsonFieldType.NUMBER).description("답글 개수"),
                                     fieldWithPath("content").type(JsonFieldType.STRING).description("댓글 내용"),
                                     fieldWithPath("createdAt").type(JsonFieldType.STRING).description("댓글 생성일"),
                                     fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("댓글 수정일")
@@ -606,9 +608,9 @@ class VoteControllerTest extends PresentationTest {
             // given
             final Long voteId = 1L;
             final String memberImageURL = "https://.../image.jpg";
-            final CommentResponse commentResponse1 = new CommentResponse(5L, 1L, memberImageURL,false, 33, "이옷 정말 예뻐요~!", LocalDateTime.now(), LocalDateTime.now());
-            final CommentResponse commentResponse2 = new CommentResponse(4L, 2L,memberImageURL, false, 31, "강추 강추!", LocalDateTime.now(), LocalDateTime.now());
-            final CommentResponse commentResponse3 = new CommentResponse(3L, 3L,memberImageURL, false, 22, "좋네요", LocalDateTime.now(), LocalDateTime.now());
+            final CommentResponse commentResponse1 = new CommentResponse(5L, 1L, "사과나무", memberImageURL,false, 33, 1, "이옷 정말 예뻐요~!", LocalDateTime.now(), LocalDateTime.now());
+            final CommentResponse commentResponse2 = new CommentResponse(4L, 2L, "느티나무", memberImageURL, false, 31, 10, "강추 강추!", LocalDateTime.now(), LocalDateTime.now());
+            final CommentResponse commentResponse3 = new CommentResponse(3L, 3L, "포도나무", memberImageURL, false, 22, 24, "좋네요", LocalDateTime.now(), LocalDateTime.now());
 
             given(voteService.searchAllComments(any(), any())).willReturn(List.of(commentResponse1, commentResponse2, commentResponse3));
 
@@ -632,9 +634,11 @@ class VoteControllerTest extends PresentationTest {
                     responseFields(
                             subsectionWithPath("[].id").type(JsonFieldType.NUMBER).description("댓글 ID"),
                             subsectionWithPath("[].memberId").type(JsonFieldType.NUMBER).description("댓글 작성자 ID"),
+                            subsectionWithPath("[].nickName").type(JsonFieldType.STRING).description("작성자 닉네임"),
                             subsectionWithPath("[].memberImageUrl").type(JsonFieldType.STRING).description("댓글 작성자 프로필 이미지 URL"),
                             subsectionWithPath("[].liked").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
                             subsectionWithPath("[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                            subsectionWithPath("[].replyCount").type(JsonFieldType.NUMBER).description("답글 개수"),
                             subsectionWithPath("[].content").type(JsonFieldType.STRING).description("댓글 내용"),
                             subsectionWithPath("[].createdAt").type(JsonFieldType.STRING).description("댓글 생성일"),
                             subsectionWithPath("[].updatedAt").type(JsonFieldType.STRING).description("댓글 수정일")


### PR DESCRIPTION
# 📌 연관 이슈

- #60 
- #92 

# 🧑‍💻 작업 내역

- [x] 대댓글 생성 기능 구현
- [x] API 문서화
- [x] 대댓글 생성 시 답글 개수 증가
- [x] 투표 댓글 목록 조회 시 댓글마다 답글 개수 응답으로 반환

# 🧐 구현사항

대댓글 생성 후, 동시성 이슈를 고려하여 여러가지 방법(JPA 변경감지, 분산락 등)을 고민했지만 DB 단에서 update 쿼리를 통해 직접 답글 개수를 증가시키도록 구현했음