### PR TITLE
fix: 투표 페이지네이션 제대로 동작하지 않는 문제 해결

### DIFF
--- a/src/test/java/com/salmalteam/salmal/domain/vote/VoteRepositoryTest.java
+++ b/src/test/java/com/salmalteam/salmal/domain/vote/VoteRepositoryTest.java
@@ -162,6 +162,7 @@ class VoteRepositoryTest extends RepositoryTest {
             voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(1L);
             voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(2L);
             voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(2L);
+            voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(2L);
             voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(3L);
             voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(3L);
             voteRepository.updateVoteEvaluationStatisticsForEvaluationLikeInsert(3L);
@@ -174,10 +175,11 @@ class VoteRepositoryTest extends RepositoryTest {
 
             // then
             List<VoteResponse> votes = votePageResponse.getVotes();
+
             Assertions.assertAll(
-                    () -> assertThat(votes.size()).isEqualTo(3),
+                    () -> assertThat(votes.size()).isEqualTo(2),
                     () -> assertThat(votes.get(0).getLikeCount()).isEqualTo(3),
-                    () -> assertThat(votes.get(2).getLikeCount()).isEqualTo(2)
+                    () -> assertThat(votes.get(1).getLikeCount()).isEqualTo(2)
             );
         }
     }


### PR DESCRIPTION
# 📌 연관 이슈

- #108 

# 🧑‍💻 작업 내역

- [x] 투표 페이지네이션 제대로 동작하지 않는 문제 해결

# 유의사항

- BEST : 좋아요 많은 순 조회 (좋아요 같은 경우 최신순)
- HOME : 최신순 조회

원래 HOME 타입의 경우 랜덤 조회로 구현하기로 했지만, 페이지네이션 조회에서 랜덤조회 방식은 이전 조회 결과가 중복될 수 있기 때문에 불가능합니다. 따라서 일단은 최신순 조회로 구현했습니다.

> 비슷하게 생각할 수 있는 방식은 `투표 생성 시점에 중복되지 않는 랜덤한 숫자를 부여해서 그것을 기준으로 조회` 하는 정도가 생각이 나는데, 그것 또한 일종의 고정된 방식이기에 랜덤 조회라고 보기 어려운 방식입니다.