### PR TITLE
Refactoring: 회원탈퇴 구현 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### LOG ###
+!**/src/main/resources/logs/**
+**/*.log
+**/*.log.gz
+.DS_Store

--- a/src/main/java/com/salmalteam/salmal/application/comment/CommentService.java
+++ b/src/main/java/com/salmalteam/salmal/application/comment/CommentService.java
@@ -1,5 +1,12 @@
 package com.salmalteam.salmal.application.comment;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.salmalteam.salmal.application.member.MemberService;
 import com.salmalteam.salmal.domain.comment.Comment;
 import com.salmalteam.salmal.domain.comment.CommentRepository;
@@ -26,13 +33,8 @@ import com.salmalteam.salmal.exception.comment.like.CommentLikeExceptionType;
 import com.salmalteam.salmal.exception.comment.report.CommentReportException;
 import com.salmalteam.salmal.exception.comment.report.CommentReportExceptionType;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/salmalteam/salmal/application/member/MemberService.java
+++ b/src/main/java/com/salmalteam/salmal/application/member/MemberService.java
@@ -223,7 +223,14 @@ public class MemberService {
 	public Member findMemberById(final Long memberId) {
 		final Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND));
+		validateActivatedMember(member);
 		return member;
+	}
+
+	private void validateActivatedMember(Member member) {
+		if (member.isRemoved()) {
+			throw new MemberException(MemberExceptionType.NOT_FOUND);
+		}
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/salmalteam/salmal/application/member/MemberService.java
+++ b/src/main/java/com/salmalteam/salmal/application/member/MemberService.java
@@ -72,7 +72,7 @@ public class MemberService {
 	 */
 	@Transactional
 	public void delete(final MemberPayLoad memberPayLoad, final Long memberId) {
-		final Member member = findMemberById(memberId);
+		final Member member = findMemberById(memberPayLoad.getId());
 		validateDeleteAuthority(memberId, memberPayLoad.getId());
 		member.remove();
 	}

--- a/src/main/java/com/salmalteam/salmal/application/member/MemberService.java
+++ b/src/main/java/com/salmalteam/salmal/application/member/MemberService.java
@@ -66,7 +66,7 @@ public class MemberService {
 	public Long save(final String provider, final SignUpRequest signUpRequest) {
 		validateNickNameExists(signUpRequest.getNickName());
 		final Member member = memberRepository.save(
-			Member.of(signUpRequest.getProviderId(), signUpRequest.getNickName(),
+			Member.createActivatedMember(signUpRequest.getProviderId(), signUpRequest.getNickName(),
 				provider, signUpRequest.getMarketingInformationConsent()));
 		return member.getId();
 	}

--- a/src/main/java/com/salmalteam/salmal/application/member/MemberService.java
+++ b/src/main/java/com/salmalteam/salmal/application/member/MemberService.java
@@ -1,7 +1,6 @@
 package com.salmalteam.salmal.application.member;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,20 +38,17 @@ public class MemberService {
 	private final ImageUploader imageUploader;
 	private final String memberImagePath;
 	private final VoteRepository voteRepository;
-	private final ApplicationEventPublisher eventPublisher;
 
 	public MemberService(final MemberRepository memberRepository,
 		final MemberBlockedRepository memberBlockedRepository,
 		final ImageUploader imageUploader,
 		@Value("${image.path.member}") final String memberImagePath,
-		final VoteRepository voteRepository,
-		final ApplicationEventPublisher eventPublisher) {
+		final VoteRepository voteRepository) {
 		this.memberRepository = memberRepository;
 		this.memberBlockedRepository = memberBlockedRepository;
 		this.imageUploader = imageUploader;
 		this.memberImagePath = memberImagePath;
 		this.voteRepository = voteRepository;
-		this.eventPublisher = eventPublisher;
 	}
 
 	@Transactional(readOnly = true)
@@ -74,13 +70,11 @@ public class MemberService {
 	/**
 	 * TODO: S3 스토리지에 올라가있는 회원 데이터(이미지) 삭제
 	 */
+	@Transactional
 	public void delete(final MemberPayLoad memberPayLoad, final Long memberId) {
-
 		final Member member = findMemberById(memberId);
 		validateDeleteAuthority(memberId, memberPayLoad.getId());
-
-		eventPublisher.publishEvent(MemberDeleteEvent.of(member.getId()));
-		memberRepository.delete(member);
+		member.remove();
 	}
 
 	private void validateDeleteAuthority(final Long memberId, final Long requesterId) {

--- a/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
+++ b/src/main/java/com/salmalteam/salmal/application/vote/VoteService.java
@@ -1,5 +1,15 @@
 package com.salmalteam.salmal.application.vote;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.salmalteam.salmal.application.ImageUploader;
 import com.salmalteam.salmal.application.comment.CommentService;
 import com.salmalteam.salmal.application.member.MemberService;
@@ -31,17 +41,8 @@ import com.salmalteam.salmal.exception.vote.bookmark.VoteBookmarkException;
 import com.salmalteam.salmal.exception.vote.bookmark.VoteBookmarkExceptionType;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 import com.salmalteam.salmal.presentation.vote.SearchTypeConstant;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
@@ -57,14 +58,14 @@ public class VoteService {
     private final ImageUploader imageUploader;
     private final String voteImagePath;
     public VoteService(final MemberService memberService,
-                       final VoteRepository voteRepository,
-                       final VoteEvaluationRepository voteEvaluationRepository,
-                       final VoteBookMarkRepository voteBookMarkRepository,
-                       final VoteReportRepository voteReportRepository,
-                       final CommentService commentService,
-                       final CommentRepository commentRepository,
-                       final ImageUploader imageUploader,
-                       @Value("${image.path.vote}") String voteImagePath){
+        final VoteRepository voteRepository,
+        final VoteEvaluationRepository voteEvaluationRepository,
+        final VoteBookMarkRepository voteBookMarkRepository,
+        final VoteReportRepository voteReportRepository,
+        final CommentService commentService,
+        final CommentRepository commentRepository,
+        final ImageUploader imageUploader,
+        @Value("${image.path.vote}") String voteImagePath){
         this.memberService = memberService;
         this.voteRepository = voteRepository;
         this.voteEvaluationRepository = voteEvaluationRepository;
@@ -106,24 +107,24 @@ public class VoteService {
     /**
      * 회원 삭제 이벤트 : 투표의 평가 개수 변경
      */
-//    @Transactional
-//    public void decreaseEvaluationCountByMemberDelete(final Long memberId){
-//
-//        // 회원이 평가한 평가 목록 조회
-//        final List<VoteEvaluation> voteEvaluations = voteEvaluationRepository.findAllByEvaluator_Id(memberId);
-//
-//        // 회원 평가 모두 취소 후 Count 변경
-//        for(VoteEvaluation voteEvaluation : voteEvaluations){
-//            final Vote vote = voteEvaluation.getVote();
-//            final VoteEvaluationType voteEvaluationType = voteEvaluation.getVoteEvaluationType();
-//            if(voteEvaluationType.equals(VoteEvaluationType.LIKE)){
-//                voteRepository.updateVoteEvaluationsStatisticsForEvaluationLikeDelete(vote.getId());
-//            }else {
-//                voteRepository.updateVoteEvaluationsStatisticsForEvaluationDisLikeDelete(vote.getId());
-//            }
-//        }
-//
-//    }
+    //    @Transactional
+    //    public void decreaseEvaluationCountByMemberDelete(final Long memberId){
+    //
+    //        // 회원이 평가한 평가 목록 조회
+    //        final List<VoteEvaluation> voteEvaluations = voteEvaluationRepository.findAllByEvaluator_Id(memberId);
+    //
+    //        // 회원 평가 모두 취소 후 Count 변경
+    //        for(VoteEvaluation voteEvaluation : voteEvaluations){
+    //            final Vote vote = voteEvaluation.getVote();
+    //            final VoteEvaluationType voteEvaluationType = voteEvaluation.getVoteEvaluationType();
+    //            if(voteEvaluationType.equals(VoteEvaluationType.LIKE)){
+    //                voteRepository.updateVoteEvaluationsStatisticsForEvaluationLikeDelete(vote.getId());
+    //            }else {
+    //                voteRepository.updateVoteEvaluationsStatisticsForEvaluationDisLikeDelete(vote.getId());
+    //            }
+    //        }
+    //
+    //    }
 
     /**
      * 회원 삭제 이벤트 : 투표의 댓글 개수 변경
@@ -135,7 +136,7 @@ public class VoteService {
 
         // 투표 기준으로 매핑
         final Map<Vote, List<Comment>> voteCommentsMap = comments.stream()
-                .collect(Collectors.groupingBy(Comment::getVote));
+            .collect(Collectors.groupingBy(Comment::getVote));
 
         // 투표 댓글 개수 변경
         voteCommentsMap.forEach((vote, commentList) -> {
@@ -208,7 +209,7 @@ public class VoteService {
 
         validateBookmarkExist(vote, member);
         final VoteBookMark voteBookMark = voteBookMarkRepository.findByVoteAndBookmaker(vote, member)
-                .orElse(VoteBookMark.of(member, vote));
+            .orElse(VoteBookMark.of(member, vote));
 
         voteBookMarkRepository.save(voteBookMark);
     }
@@ -286,7 +287,7 @@ public class VoteService {
 
     private Vote getVoteById(final Long voteId){
         return voteRepository.findById(voteId)
-                .orElseThrow(() -> new VoteException(VoteExceptionType.NOT_FOUND));
+            .orElseThrow(() -> new VoteException(VoteExceptionType.NOT_FOUND));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/salmalteam/salmal/domain/member/Member.java
+++ b/src/main/java/com/salmalteam/salmal/domain/member/Member.java
@@ -62,7 +62,7 @@ public class Member extends BaseEntity {
 		this.status = status;
 	}
 
-	public static Member of(final String providerId, final String nickName, final String provider,
+	public static Member createActivatedMember(final String providerId, final String nickName, final String provider,
 		final Boolean marketingInformationConsent) {
 		return Member.builder()
 			.providerId(providerId)

--- a/src/main/java/com/salmalteam/salmal/domain/member/Member.java
+++ b/src/main/java/com/salmalteam/salmal/domain/member/Member.java
@@ -82,4 +82,7 @@ public class Member extends BaseEntity {
 		this.memberImage = MemberImage.of(imageUrl);
 	}
 
+	public boolean isRemoved() {
+		return status.equals(Status.REMOVED);
+	}
 }

--- a/src/main/java/com/salmalteam/salmal/domain/member/Member.java
+++ b/src/main/java/com/salmalteam/salmal/domain/member/Member.java
@@ -1,18 +1,22 @@
 package com.salmalteam.salmal.domain.member;
 
-import com.salmalteam.salmal.domain.BaseEntity;
-import com.salmalteam.salmal.domain.comment.Comment;
-import com.salmalteam.salmal.domain.comment.like.CommentLike;
-import com.salmalteam.salmal.domain.comment.report.CommentReport;
-import com.salmalteam.salmal.domain.vote.Vote;
-import com.salmalteam.salmal.domain.vote.bookmark.VoteBookMark;
-import com.salmalteam.salmal.domain.vote.evaluation.VoteEvaluation;
-import com.salmalteam.salmal.domain.vote.report.VoteReport;
-import lombok.*;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import com.salmalteam.salmal.domain.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
@@ -21,74 +25,61 @@ import java.util.List;
 @Table(name = "member")
 public class Member extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(name = "provider_id", nullable = false)
-    private String providerId;
+	@Column(name = "provider_id", nullable = false)
+	private String providerId;
 
-    @OneToMany(mappedBy = "commenter", cascade = CascadeType.REMOVE)
-    private List<Comment> comments = new ArrayList<>();
+	@Enumerated(EnumType.STRING)
+	private Provider provider;
 
-    @OneToMany(mappedBy = "reporter", cascade = CascadeType.REMOVE)
-    private List<CommentReport> commentReports = new ArrayList<>();
+	@Embedded
+	private NickName nickName;
 
-    @OneToMany(mappedBy = "liker", cascade = CascadeType.REMOVE)
-    private List<CommentLike> commentLikes = new ArrayList<>();
+	@Embedded
+	private Introduction introduction;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<Vote> votes = new ArrayList<>();
+	@Embedded
+	private Setting setting;
 
-    @OneToMany(mappedBy = "reporter", cascade = CascadeType.REMOVE)
-    private List<VoteReport> voteReports = new ArrayList<>();
+	@Embedded
+	private MemberImage memberImage;
 
-    @OneToMany(mappedBy = "bookmaker", cascade = CascadeType.REMOVE)
-    private List<VoteBookMark> voteBookMarks = new ArrayList<>();
+	@Enumerated(EnumType.STRING)
+	private Status status;
 
-    @OneToMany(mappedBy = "evaluator", cascade = CascadeType.REMOVE)
-    private List<VoteEvaluation> voteEvaluations = new ArrayList<>();
+	@Builder(access = AccessLevel.PRIVATE)
+	private Member(final String providerId, final String nickName, final String provider,
+		final Boolean marketingInformationConsent, Status status) {
+		this.providerId = providerId;
+		this.nickName = NickName.from(nickName);
+		this.memberImage = MemberImage.initMemberImage();
+		this.introduction = Introduction.initIntroduction();
+		this.provider = Provider.from(provider);
+		this.setting = Setting.of(marketingInformationConsent);
+		this.status = status;
+	}
 
-    @Enumerated(EnumType.STRING)
-    private Provider provider;
+	public static Member of(final String providerId, final String nickName, final String provider,
+		final Boolean marketingInformationConsent) {
+		return Member.builder()
+			.providerId(providerId)
+			.nickName(nickName)
+			.provider(provider)
+			.marketingInformationConsent(marketingInformationConsent)
+			.status(Status.ACTIVATED)
+			.build();
+	}
 
-    @Embedded
-    private NickName nickName;
+	public void updateMyPage(final String nickName, final String introduction) {
+		this.nickName = NickName.from(nickName);
+		this.introduction = Introduction.from(introduction);
+	}
 
-    @Embedded
-    private Introduction introduction;
-
-    @Embedded
-    private Setting setting;
-
-    @Embedded
-    private MemberImage memberImage;
-
-    @Builder(access = AccessLevel.PRIVATE)
-    private Member(final String providerId, final String nickName, final String provider, final Boolean marketingInformationConsent){
-        this.providerId = providerId;
-        this.nickName = NickName.from(nickName);
-        this.memberImage = MemberImage.initMemberImage();
-        this.introduction = Introduction.initIntroduction();
-        this.provider = Provider.from(provider);
-        this.setting = Setting.of(marketingInformationConsent);
-    }
-    public static Member of(final String providerId, final String nickName, final String provider, final Boolean marketingInformationConsent){
-        return Member.builder()
-                .providerId(providerId)
-                .nickName(nickName)
-                .provider(provider)
-                .marketingInformationConsent(marketingInformationConsent)
-                .build();
-    }
-
-    public void updateMyPage(final String nickName, final String introduction){
-        this.nickName = NickName.from(nickName);
-        this.introduction = Introduction.from(introduction);
-    }
-
-    public void updateImage(final String imageUrl){
-        this.memberImage = MemberImage.of(imageUrl);
-    }
+	public void updateImage(final String imageUrl) {
+		this.memberImage = MemberImage.of(imageUrl);
+	}
 
 }

--- a/src/main/java/com/salmalteam/salmal/domain/member/Member.java
+++ b/src/main/java/com/salmalteam/salmal/domain/member/Member.java
@@ -85,4 +85,8 @@ public class Member extends BaseEntity {
 	public boolean isRemoved() {
 		return status.equals(Status.REMOVED);
 	}
+
+	public void remove() {
+		status = Status.REMOVED;
+	}
 }

--- a/src/main/java/com/salmalteam/salmal/domain/member/Status.java
+++ b/src/main/java/com/salmalteam/salmal/domain/member/Status.java
@@ -1,0 +1,6 @@
+package com.salmalteam.salmal.domain.member;
+
+public enum Status {
+	REMOVED,
+	ACTIVATED
+}

--- a/src/main/java/com/salmalteam/salmal/presentation/member/MemberController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/member/MemberController.java
@@ -1,5 +1,20 @@
 package com.salmalteam.salmal.presentation.member;
 
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.salmalteam.salmal.application.member.MemberService;
 import com.salmalteam.salmal.dto.request.member.MemberImageUpdateRequest;
 import com.salmalteam.salmal.dto.request.member.MyPageUpdateRequest;
@@ -15,11 +30,8 @@ import com.salmalteam.salmal.dto.response.member.vote.MemberVotePageResponse;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 import com.salmalteam.salmal.presentation.Login;
 import com.salmalteam.salmal.presentation.LoginMember;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/test/java/com/salmalteam/salmal/application/comment/CommentServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/comment/CommentServiceTest.java
@@ -1,11 +1,24 @@
 package com.salmalteam.salmal.application.comment;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.salmalteam.salmal.application.member.MemberService;
 import com.salmalteam.salmal.domain.comment.Comment;
+import com.salmalteam.salmal.domain.comment.CommentRepository;
 import com.salmalteam.salmal.domain.comment.like.CommentLikeRepository;
 import com.salmalteam.salmal.domain.comment.report.CommentReportRepository;
 import com.salmalteam.salmal.domain.member.Member;
-import com.salmalteam.salmal.domain.comment.CommentRepository;
 import com.salmalteam.salmal.domain.vote.Vote;
 import com.salmalteam.salmal.dto.request.vote.VoteCommentUpdateRequest;
 import com.salmalteam.salmal.exception.comment.CommentException;
@@ -14,20 +27,6 @@ import com.salmalteam.salmal.exception.comment.report.CommentReportException;
 import com.salmalteam.salmal.exception.member.MemberException;
 import com.salmalteam.salmal.exception.member.MemberExceptionType;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {

--- a/src/test/java/com/salmalteam/salmal/application/comment/CommentServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/comment/CommentServiceTest.java
@@ -67,7 +67,7 @@ class CommentServiceTest {
             final Long commentId = 1L;
             final String content = "수정할 댓글입니다";
             final VoteCommentUpdateRequest voteCommentUpdateRequest = new VoteCommentUpdateRequest(content);
-            final Member member = Member.of("LLLLLLL", "닉네임", "KAKAO", true);
+            final Member member = Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true);
 
             given(memberService.findMemberById(any())).willReturn(member);
             given(commentRepository.findById(any())).willReturn(Optional.empty());
@@ -104,7 +104,7 @@ class CommentServiceTest {
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long commentId = 1L;
 
-            final Member member = Member.of("xxx", "닉네임", "kakao", true);
+            final Member member = Member.createActivatedMember("xxx", "닉네임", "kakao", true);
             final Vote vote = Vote.of("imageUrl", member);
             final Comment comment = Comment.of("댓글", vote, member);
 
@@ -146,7 +146,7 @@ class CommentServiceTest {
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long commentId = 1L;
 
-            final Member member = Member.of("xxx", "닉네임", "kakao", true);
+            final Member member = Member.createActivatedMember("xxx", "닉네임", "kakao", true);
             final Vote vote = Vote.of("imageUrl", member);
             final Comment comment = Comment.of("댓글", vote, member);
 
@@ -185,7 +185,7 @@ class CommentServiceTest {
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long commentId = 1L;
 
-            final Member member = Member.of("ss", "닉네임", "kakao", true);
+            final Member member = Member.createActivatedMember("ss", "닉네임", "kakao", true);
             final Vote vote = Vote.of("imageUrl", member);
             final Comment comment = Comment.of("내용", vote, member);
             given(memberService.findMemberById(eq(memberId))).willReturn(member);

--- a/src/test/java/com/salmalteam/salmal/application/member/MemberServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/member/MemberServiceTest.java
@@ -30,309 +30,352 @@ import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-    @InjectMocks
-    MemberService memberService;
-    @Mock
-    MemberRepository memberRepository;
-    @Mock
-    MemberBlockedRepository memberBlockedRepository;
+	@InjectMocks
+	MemberService memberService;
+	@Mock
+	MemberRepository memberRepository;
+	@Mock
+	MemberBlockedRepository memberBlockedRepository;
 
-    @Nested
-    class 회원_저장_테스트{
-        @Test
-        void 이미_존재하는_닉네임의_경우_예외가_발생한다(){
-            // given
-            final String provider = "KAKAO";
-            final String providerId = "providerId";
-            final String nickName = "닉네임";
-            final Boolean marketingInformationConsent = true;
-            final SignUpRequest signUpRequest = new SignUpRequest(providerId, nickName, marketingInformationConsent);
-            given(memberRepository.existsByNickName(any())).willReturn(true);
+	@Nested
+	class 회원_저장_테스트 {
+		@Test
+		void 이미_존재하는_닉네임의_경우_예외가_발생한다() {
+			// given
+			final String provider = "KAKAO";
+			final String providerId = "providerId";
+			final String nickName = "닉네임";
+			final Boolean marketingInformationConsent = true;
+			final SignUpRequest signUpRequest = new SignUpRequest(providerId, nickName, marketingInformationConsent);
+			given(memberRepository.existsByNickName(any())).willReturn(true);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.save(provider, signUpRequest)).isInstanceOf(MemberException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> memberService.save(provider, signUpRequest)).isInstanceOf(MemberException.class);
+		}
+	}
 
-    @Nested
-    class providerId_로_회원_조회_테스트{
-        @Test
-        void 회원이_존재하지_않으면_예외가_발생한다(){
+	@Nested
+	class providerId_로_회원_조회_테스트 {
+		@Test
+		void 회원이_존재하지_않으면_예외가_발생한다() {
 
-            // given
-            final String providerId = "providerId";
-            given(memberRepository.findByProviderId(eq(providerId))).willReturn(Optional.empty());
+			// given
+			final String providerId = "providerId";
+			given(memberRepository.findByProviderId(eq(providerId))).willReturn(Optional.empty());
 
-            // when & then
-            assertThatThrownBy(() -> memberService.findMemberIdByProviderId(providerId)).isInstanceOf(MemberException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> memberService.findMemberIdByProviderId(providerId)).isInstanceOf(
+				MemberException.class);
+		}
+	}
 
-    @Nested
-    class Id_로_회원_조회_테스트{
-        @Test
-        void 회원이_존재하지_않으면_예외가_발생한다(){
-            // given
-            final Long id = 1L;
-            given(memberRepository.findById(eq(id))).willReturn(Optional.empty());
+	@Nested
+	class Id_로_회원_조회_테스트 {
+		@Test
+		void 회원이_존재하지_않으면_예외가_발생한다() {
+			// given
+			final Long id = 1L;
+			given(memberRepository.findById(eq(id))).willReturn(Optional.empty());
 
-            // when & then
-            assertThatThrownBy(() -> memberService.findMemberById(id))
-                    .isInstanceOf(MemberException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> memberService.findMemberById(id))
+				.isInstanceOf(MemberException.class);
+		}
+	}
 
-    @Nested
-    class 마이페이지_조회_테스트{
-        @Test
-        void 마이페이지를_조회할_회원이_존재하지_않으면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            given(memberRepository.existsById(eq(memberId))).willReturn(false);
+	@Nested
+	class 마이페이지_조회_테스트 {
+		@Test
+		void 마이페이지를_조회할_회원이_존재하지_않으면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			given(memberRepository.existsById(eq(memberId))).willReturn(false);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.findMyPage(memberId))
-                    .isInstanceOf(MemberException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> memberService.findMyPage(memberId))
+				.isInstanceOf(MemberException.class);
+		}
+	}
 
-    @Nested
-    class 회원_차단_테스트{
-        @Test
-        void 이미_차단한_회원이면_예외가_발생한다(){
+	@Nested
+	class 회원_차단_테스트 {
+		@Test
+		void 이미_차단한_회원이면_예외가_발생한다() {
 
-            // given
-            final Long memberId = 1L;
-            final Long targetMemberId = 2L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			// given
+			final Long memberId = 1L;
+			final Long targetMemberId = 2L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
 
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(Member.createActivatedMember("kk", "닉네임 A", "kakao", true)));
-            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(Member.createActivatedMember("ksk", "닉네임 B", "kakao", true)));
-            given(memberBlockedRepository.existsByBlockerAndTarget(any(), any())).willReturn(true);
+			given(memberRepository.findById(eq(memberId))).willReturn(
+				Optional.of(Member.createActivatedMember("kk", "닉네임 A", "kakao", true)));
+			given(memberRepository.findById(eq(targetMemberId))).willReturn(
+				Optional.of(Member.createActivatedMember("ksk", "닉네임 B", "kakao", true)));
+			given(memberBlockedRepository.existsByBlockerAndTarget(any(), any())).willReturn(true);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.block(memberPayLoad, targetMemberId))
-                    .isInstanceOf(MemberBlockedException.class);
+			// when & then
+			assertThatThrownBy(() -> memberService.block(memberPayLoad, targetMemberId))
+				.isInstanceOf(MemberBlockedException.class);
 
-        }
-    }
+		}
+	}
 
-    @Nested
-    class 회원_차단_취소_테스트{
-        @Test
-        void 차단한_적이_없는_회원이라면_예외가_발생한다(){
+	@Nested
+	class 회원_차단_취소_테스트 {
+		@Test
+		void 차단한_적이_없는_회원이라면_예외가_발생한다() {
 
-            // given
-            final Long memberId = 1L;
-            final Long targetMemberId = 2L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			// given
+			final Long memberId = 1L;
+			final Long targetMemberId = 2L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
 
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(Member.createActivatedMember("kk", "닉네임 A", "kakao", true)));
-            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(Member.createActivatedMember("ksk", "닉네임 B", "kakao", true)));
-            given(memberBlockedRepository.existsByBlockerAndTarget(any(), any())).willReturn(false);
+			given(memberRepository.findById(eq(memberId))).willReturn(
+				Optional.of(Member.createActivatedMember("kk", "닉네임 A", "kakao", true)));
+			given(memberRepository.findById(eq(targetMemberId))).willReturn(
+				Optional.of(Member.createActivatedMember("ksk", "닉네임 B", "kakao", true)));
+			given(memberBlockedRepository.existsByBlockerAndTarget(any(), any())).willReturn(false);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.cancelBlocking(memberPayLoad, targetMemberId))
-                    .isInstanceOf(MemberBlockedException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> memberService.cancelBlocking(memberPayLoad, targetMemberId))
+				.isInstanceOf(MemberBlockedException.class);
+		}
+	}
 
-    @Nested
-    class 회원_차단_목록_조회_테스트{
-        @Test
-        void 요청자가_존재하지_않으면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final Long targetMemberId = 2L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final MemberBlockedPageRequest memberBlockedPageRequest = MemberBlockedPageRequest.of(1L, 3);
+	@Nested
+	class 회원_차단_목록_조회_테스트 {
+		@Test
+		void 요청자가_존재하지_않으면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final Long targetMemberId = 2L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final MemberBlockedPageRequest memberBlockedPageRequest = MemberBlockedPageRequest.of(1L, 3);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.searchBlockedMembers(memberPayLoad, targetMemberId, memberBlockedPageRequest))
-                    .isInstanceOf(MemberException.class);
-        }
+			// when & then
+			assertThatThrownBy(
+				() -> memberService.searchBlockedMembers(memberPayLoad, targetMemberId, memberBlockedPageRequest))
+				.isInstanceOf(MemberException.class);
+		}
 
-        @Test
-        void 차단_목록을_조회할_회원이_존재하지_않으면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final Long targetMemberId = 2L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final MemberBlockedPageRequest memberBlockedPageRequest = MemberBlockedPageRequest.of(1L, 3);
-            final Member member = Member.createActivatedMember("LL", "닉네임", "kakao", true);
+		@Test
+		void 차단_목록을_조회할_회원이_존재하지_않으면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final Long targetMemberId = 2L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final MemberBlockedPageRequest memberBlockedPageRequest = MemberBlockedPageRequest.of(1L, 3);
+			final Member member = Member.createActivatedMember("LL", "닉네임", "kakao", true);
 
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
+			given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
 
-            // when & then
-            assertThatThrownBy(() -> memberService.searchBlockedMembers(memberPayLoad, targetMemberId, memberBlockedPageRequest))
-                    .isInstanceOf(MemberException.class);
-        }
+			// when & then
+			assertThatThrownBy(
+				() -> memberService.searchBlockedMembers(memberPayLoad, targetMemberId, memberBlockedPageRequest))
+				.isInstanceOf(MemberException.class);
+		}
 
-        @Test
-        void 본인이_아니면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final Long targetMemberId = 2L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final MemberBlockedPageRequest memberBlockedPageRequest = MemberBlockedPageRequest.of(1L, 3);
-            final Member memberA = Member.createActivatedMember("LL", "닉네임", "kakao", true);
-            final Member memberB = Member.createActivatedMember("PP", "닉넴", "kakao", true);
+		@Test
+		void 본인이_아니면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final Long targetMemberId = 2L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final MemberBlockedPageRequest memberBlockedPageRequest = MemberBlockedPageRequest.of(1L, 3);
+			final Member memberA = Member.createActivatedMember("LL", "닉네임", "kakao", true);
+			final Member memberB = Member.createActivatedMember("PP", "닉넴", "kakao", true);
 
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
-            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
+			given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
+			given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
 
-            // when & then
-            assertThatThrownBy(() -> memberService.searchBlockedMembers(memberPayLoad, targetMemberId, memberBlockedPageRequest))
-                    .isInstanceOf(MemberBlockedException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(
+				() -> memberService.searchBlockedMembers(memberPayLoad, targetMemberId, memberBlockedPageRequest))
+				.isInstanceOf(MemberBlockedException.class);
+		}
+	}
 
-    @Nested
-    class 회원_마이페이지_수정_테스트{
+	@Nested
+	class 회원_마이페이지_수정_테스트 {
 
-        @Test
-        void 회원이_존재하지_않으면_예외가_발생한다(){
+		@Test
+		void 회원이_존재하지_않으면_예외가_발생한다() {
 
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long targetMemberId = 2L;
-            final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long targetMemberId = 2L;
+			final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
 
-            // when & then
-            assertThatThrownBy(() -> memberService.updateMyPage(memberPayLoad, targetMemberId, myPageUpdateRequest))
-                    .isInstanceOf(MemberException.class);
-        }
+			// when & then
+			assertThatThrownBy(() -> memberService.updateMyPage(memberPayLoad, targetMemberId, myPageUpdateRequest))
+				.isInstanceOf(MemberException.class);
+		}
 
-        @Test
-        void 수정할_회원이_존재하지_않으면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long targetMemberId = 2L;
-            final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
+		@Test
+		void 수정할_회원이_존재하지_않으면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long targetMemberId = 2L;
+			final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
 
-            final Member member = Member.createActivatedMember("123", "닉네임", "kakao", true);
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
+			final Member member = Member.createActivatedMember("123", "닉네임", "kakao", true);
+			given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
 
-            // when & then
-            assertThatThrownBy(() -> memberService.updateMyPage(memberPayLoad, targetMemberId, myPageUpdateRequest))
-                    .isInstanceOf(MemberException.class)
-                    .hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.NOT_FOUND);
-        }
+			// when & then
+			assertThatThrownBy(() -> memberService.updateMyPage(memberPayLoad, targetMemberId, myPageUpdateRequest))
+				.isInstanceOf(MemberException.class)
+				.hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.NOT_FOUND);
+		}
 
-        @Test
-        void 본인이_아니면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long targetMemberId = 2L;
-            final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
+		@Test
+		void 본인이_아니면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long targetMemberId = 2L;
+			final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
 
-            final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
-            final Member memberB = Member.createActivatedMember("321", "닉넴", "kakao", true);
+			final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
+			final Member memberB = Member.createActivatedMember("321", "닉넴", "kakao", true);
 
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
-            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
+			given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
+			given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
 
-            // when & then
-            assertThatThrownBy(() -> memberService.updateMyPage(memberPayLoad, targetMemberId, myPageUpdateRequest))
-                    .isInstanceOf(MemberException.class)
-                    .hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.FORBIDDEN_UPDATE);
+			// when & then
+			assertThatThrownBy(() -> memberService.updateMyPage(memberPayLoad, targetMemberId, myPageUpdateRequest))
+				.isInstanceOf(MemberException.class)
+				.hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.FORBIDDEN_UPDATE);
 
-        }
-        @Test
-        void 닉네임이_중복된다면_예외가_발생한다() {
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long targetMemberId = 1L;
-            final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
+		}
 
-            final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
+		@Test
+		void 닉네임이_중복된다면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long targetMemberId = 1L;
+			final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
 
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
-            given(memberRepository.existsByNickName(any())).willReturn(true);
+			final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.updateMyPage(memberPayLoad, targetMemberId, myPageUpdateRequest))
-                    .isInstanceOf(MemberException.class)
-                    .hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.DUPLICATED_NICKNAME);
-        }
-    }
+			given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
+			given(memberRepository.existsByNickName(any())).willReturn(true);
 
-    @Nested
-    class 회원_이미지_수정_테스트{
+			// when & then
+			assertThatThrownBy(() -> memberService.updateMyPage(memberPayLoad, targetMemberId, myPageUpdateRequest))
+				.isInstanceOf(MemberException.class)
+				.hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.DUPLICATED_NICKNAME);
+		}
+	}
 
-        @Test
-        void 회원이_존재하지_않으면_예외가_발생한다() throws Exception {
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long targetMemberId = 2L;
-            final String name = "imageFile";
-            final String fileName = "testImage.jpg";
-            final String filePath = "src/test/resources/testImages/".concat(fileName);
-            final FileInputStream fileInputStream = new FileInputStream(filePath);
-            final String contentType = "image/jpeg";
-            final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
+	@Nested
+	class 회원_이미지_수정_테스트 {
 
-            final MemberImageUpdateRequest memberImageUpdateRequest = new MemberImageUpdateRequest(multipartFile);
+		@Test
+		void 회원이_존재하지_않으면_예외가_발생한다() throws Exception {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long targetMemberId = 2L;
+			final String name = "imageFile";
+			final String fileName = "testImage.jpg";
+			final String filePath = "src/test/resources/testImages/".concat(fileName);
+			final FileInputStream fileInputStream = new FileInputStream(filePath);
+			final String contentType = "image/jpeg";
+			final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.updateImage(memberPayLoad, targetMemberId, memberImageUpdateRequest))
-                    .isInstanceOf(MemberException.class)
-                    .hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.NOT_FOUND);
-        }
+			final MemberImageUpdateRequest memberImageUpdateRequest = new MemberImageUpdateRequest(multipartFile);
 
-        @Test
-        void 수정할_회원이_존재하지_않으면_예외가_발생한다() throws Exception{
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long targetMemberId = 2L;
-            final String name = "imageFile";
-            final String fileName = "testImage.jpg";
-            final String filePath = "src/test/resources/testImages/".concat(fileName);
-            final FileInputStream fileInputStream = new FileInputStream(filePath);
-            final String contentType = "image/jpeg";
-            final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
+			// when & then
+			assertThatThrownBy(() -> memberService.updateImage(memberPayLoad, targetMemberId, memberImageUpdateRequest))
+				.isInstanceOf(MemberException.class)
+				.hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.NOT_FOUND);
+		}
 
-            final MemberImageUpdateRequest memberImageUpdateRequest = new MemberImageUpdateRequest(multipartFile);
+		@Test
+		void 수정할_회원이_존재하지_않으면_예외가_발생한다() throws Exception {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long targetMemberId = 2L;
+			final String name = "imageFile";
+			final String fileName = "testImage.jpg";
+			final String filePath = "src/test/resources/testImages/".concat(fileName);
+			final FileInputStream fileInputStream = new FileInputStream(filePath);
+			final String contentType = "image/jpeg";
+			final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
 
-            final Member member = Member.createActivatedMember("123", "닉네임", "kakao", true);
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
+			final MemberImageUpdateRequest memberImageUpdateRequest = new MemberImageUpdateRequest(multipartFile);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.updateImage(memberPayLoad, targetMemberId, memberImageUpdateRequest))
-                    .isInstanceOf(MemberException.class)
-                    .hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.NOT_FOUND);
+			final Member member = Member.createActivatedMember("123", "닉네임", "kakao", true);
+			given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
 
-        }
+			// when & then
+			assertThatThrownBy(() -> memberService.updateImage(memberPayLoad, targetMemberId, memberImageUpdateRequest))
+				.isInstanceOf(MemberException.class)
+				.hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.NOT_FOUND);
 
-        @Test
-        void 본인이_아니라면_수정할_수_없다() throws Exception{
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long targetMemberId = 2L;
-            final String name = "imageFile";
-            final String fileName = "testImage.jpg";
-            final String filePath = "src/test/resources/testImages/".concat(fileName);
-            final FileInputStream fileInputStream = new FileInputStream(filePath);
-            final String contentType = "image/jpeg";
-            final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
+		}
 
-            final MemberImageUpdateRequest memberImageUpdateRequest = new MemberImageUpdateRequest(multipartFile);
-            final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
-            final Member memberB = Member.createActivatedMember("321", "닉넴", "kakao", true);
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
-            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
+		@Test
+		void 본인이_아니라면_수정할_수_없다() throws Exception {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long targetMemberId = 2L;
+			final String name = "imageFile";
+			final String fileName = "testImage.jpg";
+			final String filePath = "src/test/resources/testImages/".concat(fileName);
+			final FileInputStream fileInputStream = new FileInputStream(filePath);
+			final String contentType = "image/jpeg";
+			final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
 
-            // when & then
-            assertThatThrownBy(() -> memberService.updateImage(memberPayLoad, targetMemberId, memberImageUpdateRequest))
-                    .isInstanceOf(MemberException.class)
-                    .hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.FORBIDDEN_UPDATE);
-        }
-    }
+			final MemberImageUpdateRequest memberImageUpdateRequest = new MemberImageUpdateRequest(multipartFile);
+			final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
+			final Member memberB = Member.createActivatedMember("321", "닉넴", "kakao", true);
+			given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
+			given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
+
+			// when & then
+			assertThatThrownBy(() -> memberService.updateImage(memberPayLoad, targetMemberId, memberImageUpdateRequest))
+				.isInstanceOf(MemberException.class)
+				.hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.FORBIDDEN_UPDATE);
+		}
+	}
+
+	@Nested
+	class 회원_탈퇴_테스트 {
+		@Test
+		void 회원_탈퇴_시_활성상태가_remove_로_변경되어야한다() throws Exception {
+			//given
+			MemberPayLoad memberPayLoad = MemberPayLoad.from(100L);
+			Member activatedMember = Member.createActivatedMember("1111111", "tray", "Apple", true);
+			given(memberRepository.findById(anyLong()))
+				.willReturn(Optional.of(activatedMember));
+
+			//when
+			memberService.delete(memberPayLoad, 100L);
+
+			//then
+			then(memberRepository).should(times(1)).findById(anyLong());
+		}
+
+		@Test
+		void 회원_탈퇴_시_payload_와_path_회원_아이디가_일치하지_않을_시_예외_발생() throws Exception {
+			//given
+			MemberPayLoad memberPayLoad = MemberPayLoad.from(100L);
+			Member activatedMember = Member.createActivatedMember("1111111", "tray", "Apple", true);
+			given(memberRepository.findById(anyLong()))
+				.willReturn(Optional.of(activatedMember));
+
+			//expect
+			assertThatThrownBy(() -> memberService.delete(memberPayLoad, 500L))
+				.isInstanceOf(MemberException.class)
+				.hasFieldOrPropertyWithValue("exceptionType", MemberExceptionType.FORBIDDEN_DELETE);
+			then(memberRepository).should(times(1)).findById(anyLong());
+
+		}
+	}
 }

--- a/src/test/java/com/salmalteam/salmal/application/member/MemberServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/member/MemberServiceTest.java
@@ -106,8 +106,8 @@ class MemberServiceTest {
             final Long targetMemberId = 2L;
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
 
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(Member.of("kk", "닉네임 A", "kakao", true)));
-            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(Member.of("ksk", "닉네임 B", "kakao", true)));
+            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(Member.createActivatedMember("kk", "닉네임 A", "kakao", true)));
+            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(Member.createActivatedMember("ksk", "닉네임 B", "kakao", true)));
             given(memberBlockedRepository.existsByBlockerAndTarget(any(), any())).willReturn(true);
 
             // when & then
@@ -127,8 +127,8 @@ class MemberServiceTest {
             final Long targetMemberId = 2L;
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
 
-            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(Member.of("kk", "닉네임 A", "kakao", true)));
-            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(Member.of("ksk", "닉네임 B", "kakao", true)));
+            given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(Member.createActivatedMember("kk", "닉네임 A", "kakao", true)));
+            given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(Member.createActivatedMember("ksk", "닉네임 B", "kakao", true)));
             given(memberBlockedRepository.existsByBlockerAndTarget(any(), any())).willReturn(false);
 
             // when & then
@@ -159,7 +159,7 @@ class MemberServiceTest {
             final Long targetMemberId = 2L;
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final MemberBlockedPageRequest memberBlockedPageRequest = MemberBlockedPageRequest.of(1L, 3);
-            final Member member = Member.of("LL", "닉네임", "kakao", true);
+            final Member member = Member.createActivatedMember("LL", "닉네임", "kakao", true);
 
             given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
 
@@ -175,8 +175,8 @@ class MemberServiceTest {
             final Long targetMemberId = 2L;
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final MemberBlockedPageRequest memberBlockedPageRequest = MemberBlockedPageRequest.of(1L, 3);
-            final Member memberA = Member.of("LL", "닉네임", "kakao", true);
-            final Member memberB = Member.of("PP", "닉넴", "kakao", true);
+            final Member memberA = Member.createActivatedMember("LL", "닉네임", "kakao", true);
+            final Member memberB = Member.createActivatedMember("PP", "닉넴", "kakao", true);
 
             given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
             given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
@@ -212,7 +212,7 @@ class MemberServiceTest {
             final Long targetMemberId = 2L;
             final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
 
-            final Member member = Member.of("123", "닉네임", "kakao", true);
+            final Member member = Member.createActivatedMember("123", "닉네임", "kakao", true);
             given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
 
             // when & then
@@ -229,8 +229,8 @@ class MemberServiceTest {
             final Long targetMemberId = 2L;
             final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
 
-            final Member memberA = Member.of("123", "닉네임", "kakao", true);
-            final Member memberB = Member.of("321", "닉넴", "kakao", true);
+            final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
+            final Member memberB = Member.createActivatedMember("321", "닉넴", "kakao", true);
 
             given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
             given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
@@ -249,7 +249,7 @@ class MemberServiceTest {
             final Long targetMemberId = 1L;
             final MyPageUpdateRequest myPageUpdateRequest = new MyPageUpdateRequest("수정할 닉네임", "수정할 한줄 소개");
 
-            final Member memberA = Member.of("123", "닉네임", "kakao", true);
+            final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
 
             given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
             given(memberRepository.existsByNickName(any())).willReturn(true);
@@ -300,7 +300,7 @@ class MemberServiceTest {
 
             final MemberImageUpdateRequest memberImageUpdateRequest = new MemberImageUpdateRequest(multipartFile);
 
-            final Member member = Member.of("123", "닉네임", "kakao", true);
+            final Member member = Member.createActivatedMember("123", "닉네임", "kakao", true);
             given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(member));
 
             // when & then
@@ -324,8 +324,8 @@ class MemberServiceTest {
             final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
 
             final MemberImageUpdateRequest memberImageUpdateRequest = new MemberImageUpdateRequest(multipartFile);
-            final Member memberA = Member.of("123", "닉네임", "kakao", true);
-            final Member memberB = Member.of("321", "닉넴", "kakao", true);
+            final Member memberA = Member.createActivatedMember("123", "닉네임", "kakao", true);
+            final Member memberB = Member.createActivatedMember("321", "닉넴", "kakao", true);
             given(memberRepository.findById(eq(memberId))).willReturn(Optional.of(memberA));
             given(memberRepository.findById(eq(targetMemberId))).willReturn(Optional.of(memberB));
 

--- a/src/test/java/com/salmalteam/salmal/application/member/MemberServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/member/MemberServiceTest.java
@@ -1,5 +1,20 @@
 package com.salmalteam.salmal.application.member;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.io.FileInputStream;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
 import com.salmalteam.salmal.domain.member.Member;
 import com.salmalteam.salmal.domain.member.MemberRepository;
 import com.salmalteam.salmal.domain.member.block.MemberBlockedRepository;
@@ -11,26 +26,6 @@ import com.salmalteam.salmal.exception.member.MemberException;
 import com.salmalteam.salmal.exception.member.MemberExceptionType;
 import com.salmalteam.salmal.exception.member.block.MemberBlockedException;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.lang.reflect.Field;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.anyOf;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {

--- a/src/test/java/com/salmalteam/salmal/application/vote/VoteServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/vote/VoteServiceTest.java
@@ -1,5 +1,21 @@
 package com.salmalteam.salmal.application.vote;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
 import com.salmalteam.salmal.application.ImageUploader;
 import com.salmalteam.salmal.application.member.MemberService;
 import com.salmalteam.salmal.domain.member.Member;
@@ -16,24 +32,6 @@ import com.salmalteam.salmal.exception.member.MemberExceptionType;
 import com.salmalteam.salmal.exception.vote.VoteException;
 import com.salmalteam.salmal.exception.vote.bookmark.VoteBookmarkException;
 import com.salmalteam.salmal.infra.auth.dto.MemberPayLoad;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class VoteServiceTest {
@@ -90,7 +88,7 @@ class VoteServiceTest {
             final Long voteId = 1L;
             final String voteEvaluationTypeStr = "LIKE";
             final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluationTypeStr);
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
+            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
             given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
             // when & then
@@ -107,8 +105,8 @@ class VoteServiceTest {
             final String voteEvaluationTypeStr = "LIKE";
             final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluationTypeStr);
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", Member.of("LLLLLLL", "닉네임", "KAKAO", true))));
+            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
+            given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true))));
             given(voteEvaluationRepository.existsByEvaluatorAndVoteAndVoteEvaluationType(any(), any(), any())).willReturn(true);
 
             // when & then
@@ -127,7 +125,7 @@ class VoteServiceTest {
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long voteId = 1L;
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
+            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
             given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
             // when & then
@@ -141,7 +139,7 @@ class VoteServiceTest {
             final Long memberId = 1L;
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long voteId = 1L;
-            final Member member = Member.of("LLLLLLL", "닉네임", "KAKAO", true);
+            final Member member = Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true);
 
             given(memberService.findMemberById(eq(memberId))).willReturn(member);
             given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", member)));
@@ -196,7 +194,7 @@ class VoteServiceTest {
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long voteId = 1L;
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
+            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
             given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
             // when & then
@@ -211,8 +209,8 @@ class VoteServiceTest {
             final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
             final Long voteId = 1L;
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", Member.of("LLLLLLL", "닉네임", "KAKAO", true))));
+            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
+            given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true))));
             given(voteReportRepository.existsByVoteAndReporter(any(), any())).willReturn(true);
 
             // when & then
@@ -249,7 +247,7 @@ class VoteServiceTest {
             final String content = "댓글입니다";
             final VoteCommentCreateRequest voteCommentCreateRequest = new VoteCommentCreateRequest(content);
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.of("LLLLLLL", "닉네임", "KAKAO", true));
+            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
             given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
             // when & then

--- a/src/test/java/com/salmalteam/salmal/domain/vote/VoteRepositoryTest.java
+++ b/src/test/java/com/salmalteam/salmal/domain/vote/VoteRepositoryTest.java
@@ -1,5 +1,18 @@
 package com.salmalteam.salmal.domain.vote;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
 import com.salmalteam.salmal.domain.comment.CommentRepository;
 import com.salmalteam.salmal.domain.member.Member;
 import com.salmalteam.salmal.domain.member.MemberRepository;
@@ -13,17 +26,6 @@ import com.salmalteam.salmal.dto.response.vote.VotePageResponse;
 import com.salmalteam.salmal.dto.response.vote.VoteResponse;
 import com.salmalteam.salmal.presentation.vote.SearchTypeConstant;
 import com.salmalteam.salmal.support.RepositoryTest;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
-
-import javax.persistence.EntityManager;
-import java.math.BigDecimal;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class VoteRepositoryTest extends RepositoryTest {
 

--- a/src/test/java/com/salmalteam/salmal/domain/vote/VoteRepositoryTest.java
+++ b/src/test/java/com/salmalteam/salmal/domain/vote/VoteRepositoryTest.java
@@ -54,7 +54,7 @@ class VoteRepositoryTest extends RepositoryTest {
         // given
         final Long voteId = 1L;
         final Long memberId = 1L;
-        final Member member = Member.of("pro", "닉네임1", "kakao", true);
+        final Member member = Member.createActivatedMember("pro", "닉네임1", "kakao", true);
         final Vote vote = Vote.of("imageUrl", member);
         final VoteEvaluation voteEvaluation = VoteEvaluation.of(vote, member, VoteEvaluationType.LIKE);
         final VoteBookMark voteBookMark = VoteBookMark.of(member, vote);
@@ -85,7 +85,7 @@ class VoteRepositoryTest extends RepositoryTest {
         void 싫어요_1_좋아요_1인_상태에서_좋아요를_추가(){
             // given
             final Long voteId = 1L;
-            final Member member = Member.of("pro", "닉네임1", "kakao", true);
+            final Member member = Member.createActivatedMember("pro", "닉네임1", "kakao", true);
             final Vote vote = Vote.of("imageUrl", member);
 
             memberRepository.save(member);
@@ -117,9 +117,9 @@ class VoteRepositoryTest extends RepositoryTest {
         void 좋아요_평가_목록_조회_테스트(){
             // given
             final Long memberId = 1L;
-            final Member memberA = Member.of("pro1", "닉네임1", "kakao", true);
-            final Member memberB = Member.of("pro2", "닉네임2", "kakao", true);
-            final Member memberC = Member.of("pro3", "닉네임3", "kakao", true);
+            final Member memberA = Member.createActivatedMember("pro1", "닉네임1", "kakao", true);
+            final Member memberB = Member.createActivatedMember("pro2", "닉네임2", "kakao", true);
+            final Member memberC = Member.createActivatedMember("pro3", "닉네임3", "kakao", true);
 
             final Vote voteA = Vote.of("imageUrl", memberA);
             final Vote voteB = Vote.of("imageUrl", memberA);


### PR DESCRIPTION
# 📌 연관 이슈
- #134 
# 🧑‍💻 작업 내역

- [x] 멤버 활성상태를 나태는 `status` 컬럼 `member`에 구현
- [x] 멤버 엔티티 간의 양방향 관계 엔티티 삭제
- [x] 회원탈퇴 API 호출 시 기존 실제 삭제 쿼리가 나가는 로직에서 활성상태를 변경하는 방법으로 변경
- [x] 회원탈퇴 단위테스트 작성

# 📚 참고 자료 (Optional)
자동 줄바꿈을 사용하다 보니 정렬을 통한 변경으로 커밋된 내역이 몇개 존재합니다.
# 🧐 더 나아가야할 점 혹은 고민 (Optional)
- #137 
- #136
