### PR TITLE
[BE] Feature: 투표, 댓글, 대댓글 조회시 차단회원은 조회결과에 포함안되는 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/salmalteam/salmal/comment/dto/response/CommentPageResponse.java
+++ b/src/main/java/com/salmalteam/salmal/comment/dto/response/CommentPageResponse.java
@@ -1,8 +1,11 @@
 package com.salmalteam.salmal.comment.dto.response;
 
-import lombok.Getter;
+import static java.util.stream.Collectors.*;
 
 import java.util.List;
+import java.util.function.Predicate;
+
+import lombok.Getter;
 
 @Getter
 public class CommentPageResponse {
@@ -15,5 +18,16 @@ public class CommentPageResponse {
 
     public static CommentPageResponse of(boolean hasNext, List<CommentResponse> comments){
         return new CommentPageResponse(hasNext, comments);
+    }
+
+    public void filteringBlockedMembers(List<Long> ids) {
+        comments = comments.stream()
+            .filter(filterBlockedMemberPredicate(ids))
+            .collect(toList());
+    }
+
+    private Predicate<CommentResponse> filterBlockedMemberPredicate(List<Long> ids) {
+        return voteResponse -> ids.stream()
+            .noneMatch(id -> id.equals(voteResponse.getMemberId()));
     }
 }

--- a/src/main/java/com/salmalteam/salmal/comment/dto/response/ReplyPageResponse.java
+++ b/src/main/java/com/salmalteam/salmal/comment/dto/response/ReplyPageResponse.java
@@ -1,20 +1,34 @@
 package com.salmalteam.salmal.comment.dto.response;
 
-import lombok.Getter;
+import static java.util.stream.Collectors.*;
 
 import java.util.List;
+import java.util.function.Predicate;
+
+import lombok.Getter;
 
 @Getter
 public class ReplyPageResponse {
-    private boolean hasNext;
-    private List<ReplyResponse> comments;
+	private boolean hasNext;
+	private List<ReplyResponse> comments;
 
-    private ReplyPageResponse(boolean hashNext, List<ReplyResponse> comments) {
-        this.hasNext = hashNext;
-        this.comments = comments;
-    }
+	private ReplyPageResponse(boolean hashNext, List<ReplyResponse> comments) {
+		this.hasNext = hashNext;
+		this.comments = comments;
+	}
 
-    public static ReplyPageResponse of(boolean hashNext, List<ReplyResponse> comments){
-        return new ReplyPageResponse(hashNext, comments);
-    }
+	public static ReplyPageResponse of(boolean hashNext, List<ReplyResponse> comments) {
+		return new ReplyPageResponse(hashNext, comments);
+	}
+
+	public void filteringBlockedMembers(List<Long> ids) {
+		comments = comments.stream()
+			.filter(filterBlockedMemberPredicate(ids))
+			.collect(toList());
+	}
+
+	private Predicate<ReplyResponse> filterBlockedMemberPredicate(List<Long> ids) {
+		return voteResponse -> ids.stream()
+			.noneMatch(id -> id.equals(voteResponse.getMemberId()));
+	}
 }

--- a/src/main/java/com/salmalteam/salmal/member/application/MemberService.java
+++ b/src/main/java/com/salmalteam/salmal/member/application/MemberService.java
@@ -1,19 +1,15 @@
 package com.salmalteam.salmal.member.application;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.salmalteam.salmal.auth.dto.request.SignUpRequest;
+import com.salmalteam.salmal.auth.entity.MemberPayLoad;
 import com.salmalteam.salmal.image.application.ImageUploader;
 import com.salmalteam.salmal.image.entity.ImageFile;
-import com.salmalteam.salmal.member.entity.Member;
-import com.salmalteam.salmal.member.entity.MemberImage;
-import com.salmalteam.salmal.member.entity.MemberRepository;
-import com.salmalteam.salmal.member.entity.NickName;
-import com.salmalteam.salmal.member.entity.MemberBlocked;
-import com.salmalteam.salmal.member.entity.MemberBlockedRepository;
-import com.salmalteam.salmal.vote.entity.VoteRepository;
-import com.salmalteam.salmal.auth.dto.request.SignUpRequest;
 import com.salmalteam.salmal.member.dto.request.MemberImageUpdateRequest;
 import com.salmalteam.salmal.member.dto.request.MyPageUpdateRequest;
 import com.salmalteam.salmal.member.dto.request.block.MemberBlockedPageRequest;
@@ -25,11 +21,17 @@ import com.salmalteam.salmal.member.dto.response.block.MemberBlockedPageResponse
 import com.salmalteam.salmal.member.dto.response.vote.MemberBookmarkVotePageResponse;
 import com.salmalteam.salmal.member.dto.response.vote.MemberEvaluationVotePageResponse;
 import com.salmalteam.salmal.member.dto.response.vote.MemberVotePageResponse;
+import com.salmalteam.salmal.member.entity.Member;
+import com.salmalteam.salmal.member.entity.MemberBlocked;
+import com.salmalteam.salmal.member.entity.MemberBlockedRepository;
+import com.salmalteam.salmal.member.entity.MemberImage;
+import com.salmalteam.salmal.member.entity.MemberRepository;
+import com.salmalteam.salmal.member.entity.NickName;
 import com.salmalteam.salmal.member.exception.MemberException;
 import com.salmalteam.salmal.member.exception.MemberExceptionType;
 import com.salmalteam.salmal.member.exception.block.MemberBlockedException;
 import com.salmalteam.salmal.member.exception.block.MemberBlockedExceptionType;
-import com.salmalteam.salmal.auth.entity.MemberPayLoad;
+import com.salmalteam.salmal.vote.entity.VoteRepository;
 
 @Service
 public class MemberService {
@@ -251,4 +253,8 @@ public class MemberService {
 		}
 	}
 
+	@Transactional(readOnly = true)
+	public List<Long> findBlockedMembers(Long memberId) {
+		return memberBlockedRepository.findTargetMemberIdByMemberId(memberId);
+	}
 }

--- a/src/main/java/com/salmalteam/salmal/member/entity/MemberBlockedRepository.java
+++ b/src/main/java/com/salmalteam/salmal/member/entity/MemberBlockedRepository.java
@@ -1,9 +1,18 @@
 package com.salmalteam.salmal.member.entity;
 
-import org.springframework.data.repository.Repository;
+import java.util.List;
 
-public interface MemberBlockedRepository extends Repository<MemberBlocked, Long>, MemberBlockedRepositoryCustom {
-    MemberBlocked save(MemberBlocked memberBlocked);
-    void deleteByBlockerAndTarget(Member blocker, Member target);
-    boolean existsByBlockerAndTarget(Member blocker, Member target);
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberBlockedRepository extends JpaRepository<MemberBlocked, Long>, MemberBlockedRepositoryCustom {
+	MemberBlocked save(MemberBlocked memberBlocked);
+
+	void deleteByBlockerAndTarget(Member blocker, Member target);
+
+	boolean existsByBlockerAndTarget(Member blocker, Member target);
+
+	@Query("select mb.target.id from MemberBlocked mb where mb.blocker.id =:blockerId")
+	List<Long> findTargetMemberIdByMemberId(@Param("blockerId") Long blockerId);
 }

--- a/src/main/java/com/salmalteam/salmal/member/entity/MemberRepository.java
+++ b/src/main/java/com/salmalteam/salmal/member/entity/MemberRepository.java
@@ -1,14 +1,11 @@
 package com.salmalteam.salmal.member.entity;
 
-import org.springframework.data.repository.Repository;
-
 import java.util.Optional;
 
-public interface MemberRepository extends Repository <Member, Long>, MemberRepositoryCustom{
-    Member save(Member member);
-    Optional<Member> findById(Long id);
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository <Member, Long>, MemberRepositoryCustom{
     Optional<Member> findByProviderId(String providerId);
     boolean existsByNickName(NickName nickName);
     boolean existsById(Long memberId);
-    void delete(Member member);
 }

--- a/src/main/java/com/salmalteam/salmal/vote/application/VoteService.java
+++ b/src/main/java/com/salmalteam/salmal/vote/application/VoteService.java
@@ -1,46 +1,42 @@
 package com.salmalteam.salmal.vote.application;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.salmalteam.salmal.image.application.ImageUploader;
+import com.salmalteam.salmal.auth.entity.MemberPayLoad;
 import com.salmalteam.salmal.comment.application.CommentService;
-import com.salmalteam.salmal.member.application.MemberService;
-import com.salmalteam.salmal.comment.entity.Comment;
+import com.salmalteam.salmal.comment.dto.request.CommentPageRequest;
+import com.salmalteam.salmal.comment.dto.response.CommentPageResponse;
+import com.salmalteam.salmal.comment.dto.response.CommentResponse;
 import com.salmalteam.salmal.comment.entity.CommentRepository;
-import com.salmalteam.salmal.comment.entity.CommentType;
+import com.salmalteam.salmal.image.application.ImageUploader;
 import com.salmalteam.salmal.image.entity.ImageFile;
+import com.salmalteam.salmal.member.application.MemberService;
 import com.salmalteam.salmal.member.entity.Member;
+import com.salmalteam.salmal.presentation.http.vote.SearchTypeConstant;
+import com.salmalteam.salmal.vote.dto.request.VoteCommentCreateRequest;
+import com.salmalteam.salmal.vote.dto.request.VoteCreateRequest;
+import com.salmalteam.salmal.vote.dto.request.VotePageRequest;
+import com.salmalteam.salmal.vote.dto.response.VotePageResponse;
+import com.salmalteam.salmal.vote.dto.response.VoteResponse;
 import com.salmalteam.salmal.vote.entity.Vote;
-import com.salmalteam.salmal.vote.entity.VoteRepository;
 import com.salmalteam.salmal.vote.entity.VoteBookMark;
 import com.salmalteam.salmal.vote.entity.VoteBookMarkRepository;
+import com.salmalteam.salmal.vote.entity.VoteRepository;
 import com.salmalteam.salmal.vote.entity.evaluation.VoteEvaluation;
 import com.salmalteam.salmal.vote.entity.evaluation.VoteEvaluationRepository;
 import com.salmalteam.salmal.vote.entity.evaluation.VoteEvaluationType;
 import com.salmalteam.salmal.vote.entity.report.VoteReport;
 import com.salmalteam.salmal.vote.entity.report.VoteReportRepository;
-import com.salmalteam.salmal.comment.dto.request.CommentPageRequest;
-import com.salmalteam.salmal.vote.dto.request.VoteCommentCreateRequest;
-import com.salmalteam.salmal.vote.dto.request.VoteCreateRequest;
-import com.salmalteam.salmal.vote.dto.request.VotePageRequest;
-import com.salmalteam.salmal.comment.dto.response.CommentPageResponse;
-import com.salmalteam.salmal.comment.dto.response.CommentResponse;
-import com.salmalteam.salmal.vote.dto.response.VotePageResponse;
-import com.salmalteam.salmal.vote.dto.response.VoteResponse;
 import com.salmalteam.salmal.vote.exception.VoteException;
 import com.salmalteam.salmal.vote.exception.VoteExceptionType;
 import com.salmalteam.salmal.vote.exception.bookmark.VoteBookmarkException;
 import com.salmalteam.salmal.vote.exception.bookmark.VoteBookmarkExceptionType;
-import com.salmalteam.salmal.auth.entity.MemberPayLoad;
-import com.salmalteam.salmal.presentation.http.vote.SearchTypeConstant;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -102,47 +98,6 @@ public class VoteService {
         if(writerId == null || writerId != requesterId){
             throw new VoteException(VoteExceptionType.FORBIDDEN_DELETE);
         }
-    }
-
-    /**
-     * 회원 삭제 이벤트 : 투표의 평가 개수 변경
-     */
-    //    @Transactional
-    //    public void decreaseEvaluationCountByMemberDelete(final Long memberId){
-    //
-    //        // 회원이 평가한 평가 목록 조회
-    //        final List<VoteEvaluation> voteEvaluations = voteEvaluationRepository.findAllByEvaluator_Id(memberId);
-    //
-    //        // 회원 평가 모두 취소 후 Count 변경
-    //        for(VoteEvaluation voteEvaluation : voteEvaluations){
-    //            final Vote vote = voteEvaluation.getVote();
-    //            final VoteEvaluationType voteEvaluationType = voteEvaluation.getVoteEvaluationType();
-    //            if(voteEvaluationType.equals(VoteEvaluationType.LIKE)){
-    //                voteRepository.updateVoteEvaluationsStatisticsForEvaluationLikeDelete(vote.getId());
-    //            }else {
-    //                voteRepository.updateVoteEvaluationsStatisticsForEvaluationDisLikeDelete(vote.getId());
-    //            }
-    //        }
-    //
-    //    }
-
-    /**
-     * 회원 삭제 이벤트 : 투표의 댓글 개수 변경
-     */
-    @Transactional
-    public void decreaseCommentCountByMemberDelete(final Long memberId){
-        // 회원이 작성한 댓글 목록 모두 조회
-        final List<Comment> comments = commentRepository.findALlByCommenter_idAndCommentType(memberId, CommentType.COMMENT);
-
-        // 투표 기준으로 매핑
-        final Map<Vote, List<Comment>> voteCommentsMap = comments.stream()
-            .collect(Collectors.groupingBy(Comment::getVote));
-
-        // 투표 댓글 개수 변경
-        voteCommentsMap.forEach((vote, commentList) -> {
-            vote.decreaseCommentCount(commentList.size());
-        });
-
     }
 
     @Transactional

--- a/src/main/java/com/salmalteam/salmal/vote/application/VoteService.java
+++ b/src/main/java/com/salmalteam/salmal/vote/application/VoteService.java
@@ -247,8 +247,10 @@ public class VoteService {
 
     @Transactional(readOnly = true)
     public VotePageResponse searchList(final MemberPayLoad memberPayLoad, final VotePageRequest votePageRequest, final SearchTypeConstant searchTypeConstant){
-
         final Long memberId = memberPayLoad.getId();
-        return voteRepository.searchList(memberId, votePageRequest, searchTypeConstant);
+        List<Long> blockedMembers = memberService.findBlockedMembers(memberId);
+        VotePageResponse votePageResponse = voteRepository.searchList(memberId, votePageRequest, searchTypeConstant);
+        votePageResponse.filteringBlockedMembers(blockedMembers);
+        return votePageResponse;
     }
 }

--- a/src/main/java/com/salmalteam/salmal/vote/application/VoteService.java
+++ b/src/main/java/com/salmalteam/salmal/vote/application/VoteService.java
@@ -216,7 +216,10 @@ public class VoteService {
     @Transactional(readOnly = true)
     public CommentPageResponse searchComments(final Long voteId, final MemberPayLoad memberPayLoad, final CommentPageRequest commentPageRequest){
         validateVoteExist(voteId);
-        return commentService.searchList(voteId, memberPayLoad, commentPageRequest);
+        List<Long> ids = memberService.findBlockedMembers(memberPayLoad.getId());
+        CommentPageResponse commentPageResponse = commentService.searchList(voteId, memberPayLoad, commentPageRequest);
+        commentPageResponse.filteringBlockedMembers(ids);
+        return commentPageResponse;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/salmalteam/salmal/vote/dto/response/VotePageResponse.java
+++ b/src/main/java/com/salmalteam/salmal/vote/dto/response/VotePageResponse.java
@@ -1,6 +1,9 @@
 package com.salmalteam.salmal.vote.dto.response;
 
+import static java.util.stream.Collectors.*;
+
 import java.util.List;
+import java.util.function.Predicate;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,15 +13,27 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class VotePageResponse {
 
-    private boolean hasNext;
-    private List<VoteResponse> votes;
+	private boolean hasNext;
+	private List<VoteResponse> votes;
 
-    private VotePageResponse(final boolean hasNext,final List<VoteResponse> voteResponses) {
-        this.hasNext = hasNext;
-        this.votes = voteResponses;
-    }
-    public static VotePageResponse of(final boolean hasNext, final List<VoteResponse> voteResponses){
-        return new VotePageResponse(hasNext, voteResponses);
-    }
+	private VotePageResponse(final boolean hasNext, final List<VoteResponse> voteResponses) {
+		this.hasNext = hasNext;
+		this.votes = voteResponses;
+	}
+
+	public static VotePageResponse of(final boolean hasNext, final List<VoteResponse> voteResponses) {
+		return new VotePageResponse(hasNext, voteResponses);
+	}
+
+	public void filteringBlockedMembers(List<Long> ids) {
+		votes = votes.stream()
+			.filter(filterBlockedMemberPredicate(ids))
+			.collect(toList());
+	}
+
+	public Predicate<VoteResponse> filterBlockedMemberPredicate(List<Long> ids) {
+		return voteResponse -> ids.stream()
+			.noneMatch(id -> id.equals(voteResponse.getMemberId()));
+	}
 
 }

--- a/src/main/java/com/salmalteam/salmal/vote/dto/response/VotePageResponse.java
+++ b/src/main/java/com/salmalteam/salmal/vote/dto/response/VotePageResponse.java
@@ -31,7 +31,7 @@ public class VotePageResponse {
 			.collect(toList());
 	}
 
-	public Predicate<VoteResponse> filterBlockedMemberPredicate(List<Long> ids) {
+	private Predicate<VoteResponse> filterBlockedMemberPredicate(List<Long> ids) {
 		return voteResponse -> ids.stream()
 			.noneMatch(id -> id.equals(voteResponse.getMemberId()));
 	}

--- a/src/test/java/com/salmalteam/salmal/application/comment/CommentServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/comment/CommentServiceTest.java
@@ -13,192 +13,243 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.salmalteam.salmal.member.application.MemberService;
+import com.salmalteam.salmal.auth.entity.MemberPayLoad;
 import com.salmalteam.salmal.comment.application.CommentService;
 import com.salmalteam.salmal.comment.entity.Comment;
 import com.salmalteam.salmal.comment.entity.CommentRepository;
 import com.salmalteam.salmal.comment.entity.like.CommentLikeRepository;
 import com.salmalteam.salmal.comment.entity.report.CommentReportRepository;
-import com.salmalteam.salmal.member.entity.Member;
-import com.salmalteam.salmal.vote.entity.Vote;
-import com.salmalteam.salmal.vote.dto.request.VoteCommentUpdateRequest;
 import com.salmalteam.salmal.comment.exception.CommentException;
 import com.salmalteam.salmal.comment.exception.like.CommentLikeException;
 import com.salmalteam.salmal.comment.exception.report.CommentReportException;
+import com.salmalteam.salmal.member.application.MemberService;
+import com.salmalteam.salmal.member.entity.Member;
 import com.salmalteam.salmal.member.exception.MemberException;
 import com.salmalteam.salmal.member.exception.MemberExceptionType;
-import com.salmalteam.salmal.auth.entity.MemberPayLoad;
+import com.salmalteam.salmal.vote.dto.request.VoteCommentUpdateRequest;
+import com.salmalteam.salmal.vote.entity.Vote;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
 
-    @InjectMocks
-    CommentService commentService;
-    @Mock
-    MemberService memberService;
-    @Mock
-    CommentRepository commentRepository;
-    @Mock
-    CommentLikeRepository commentLikeRepository;
-    @Mock
-    CommentReportRepository commentReportRepository;
+	@InjectMocks
+	CommentService commentService;
+	@Mock
+	MemberService memberService;
+	@Mock
+	CommentRepository commentRepository;
+	@Mock
+	CommentLikeRepository commentLikeRepository;
+	@Mock
+	CommentReportRepository commentReportRepository;
 
-    @Nested
-    class 댓글_수정_테스트{
+	@Nested
+	class 댓글_수정_테스트 {
 
-        @Test
-        void 요청_회원이_존재하지_않는다면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long commentId = 1L;
-            final String content = "수정할 댓글입니다";
-            final VoteCommentUpdateRequest voteCommentUpdateRequest = new VoteCommentUpdateRequest(content);
+		@Test
+		void 요청_회원이_존재하지_않는다면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long commentId = 1L;
+			final String content = "수정할 댓글입니다";
+			final VoteCommentUpdateRequest voteCommentUpdateRequest = new VoteCommentUpdateRequest(content);
 
-            given(memberService.findMemberById(any())).willThrow(new MemberException(MemberExceptionType.NOT_FOUND));
-            // when & then
-            assertThatThrownBy(() -> commentService.updateComment(memberPayLoad, commentId, voteCommentUpdateRequest))
-                    .isInstanceOf(MemberException.class);
-        }
-        @Test
-        void 수정할_댓글이_존재하지_않는다면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long commentId = 1L;
-            final String content = "수정할 댓글입니다";
-            final VoteCommentUpdateRequest voteCommentUpdateRequest = new VoteCommentUpdateRequest(content);
-            final Member member = Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true);
+			given(memberService.findMemberById(any())).willThrow(new MemberException(MemberExceptionType.NOT_FOUND));
+			// when & then
+			assertThatThrownBy(() -> commentService.updateComment(memberPayLoad, commentId, voteCommentUpdateRequest))
+				.isInstanceOf(MemberException.class);
+		}
 
-            given(memberService.findMemberById(any())).willReturn(member);
-            given(commentRepository.findById(any())).willReturn(Optional.empty());
+		@Test
+		void 수정할_댓글이_존재하지_않는다면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long commentId = 1L;
+			final String content = "수정할 댓글입니다";
+			final VoteCommentUpdateRequest voteCommentUpdateRequest = new VoteCommentUpdateRequest(content);
+			final Member member = Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true);
 
-            // when & then
-            assertThatThrownBy(() -> commentService.updateComment(memberPayLoad, commentId, voteCommentUpdateRequest))
-                    .isInstanceOf(CommentException.class);
+			given(memberService.findMemberById(any())).willReturn(member);
+			given(commentRepository.findById(any())).willReturn(Optional.empty());
 
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> commentService.updateComment(memberPayLoad, commentId, voteCommentUpdateRequest))
+				.isInstanceOf(CommentException.class);
 
-    @Nested
-    class 댓글_좋아요_테스트{
+		}
+	}
 
-        @Test
-        void 좋아요할_댓글이_존재하지_않으면_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long commentId = 1L;
+	@Nested
+	class 댓글_좋아요_테스트 {
 
-            // when & then
-            assertThatThrownBy(() -> commentService.likeComment(memberPayLoad, commentId))
-                    .isInstanceOf(CommentException.class);
+		@Test
+		void 좋아요할_댓글이_존재하지_않으면_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long commentId = 1L;
 
-            verify(memberService).findMemberById(eq(memberId));
-        }
+			// when & then
+			assertThatThrownBy(() -> commentService.likeComment(memberPayLoad, commentId))
+				.isInstanceOf(CommentException.class);
 
-        @Test
-        void 이미_좋아요를_한_경우_예외가_발생한다(){
+			verify(memberService).findMemberById(eq(memberId));
+		}
 
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long commentId = 1L;
+		@Test
+		void 이미_좋아요를_한_경우_예외가_발생한다() {
 
-            final Member member = Member.createActivatedMember("xxx", "닉네임", "kakao", true);
-            final Vote vote = Vote.of("imageUrl", member);
-            final Comment comment = Comment.of("댓글", vote, member);
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long commentId = 1L;
 
-            given(memberService.findMemberById(any())).willReturn(member);
-            given(commentRepository.findById(any())).willReturn(Optional.of(comment));
-            given(commentLikeRepository.existsByCommentAndLiker(any(), any())).willReturn(true);
+			final Member member = Member.createActivatedMember("xxx", "닉네임", "kakao", true);
+			final Vote vote = Vote.of("imageUrl", member);
+			final Comment comment = Comment.of("댓글", vote, member);
 
-            // when & then
-            assertThatThrownBy(() -> commentService.likeComment(memberPayLoad, commentId))
-                    .isInstanceOf(CommentLikeException.class);
+			given(memberService.findMemberById(any())).willReturn(member);
+			given(commentRepository.findById(any())).willReturn(Optional.of(comment));
+			given(commentLikeRepository.existsByCommentAndLiker(any(), any())).willReturn(true);
 
-        }
+			// when & then
+			assertThatThrownBy(() -> commentService.likeComment(memberPayLoad, commentId))
+				.isInstanceOf(CommentLikeException.class);
 
-    }
+		}
 
-    @Nested
-    class 댓글_좋아요_취소_테스트{
+	}
 
-        @Test
-        void 좋아요_취소할_댓글이_존재하지_않으면_예외가_발생한다(){
+	@Nested
+	class 댓글_좋아요_취소_테스트 {
 
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long commentId = 1L;
+		@Test
+		void 좋아요_취소할_댓글이_존재하지_않으면_예외가_발생한다() {
 
-            // when & then
-            assertThatThrownBy(() -> commentService.unLikeComment(memberPayLoad, commentId))
-                    .isInstanceOf(CommentException.class);
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long commentId = 1L;
 
-            verify(memberService).findMemberById(eq(memberId));
-        }
+			// when & then
+			assertThatThrownBy(() -> commentService.unLikeComment(memberPayLoad, commentId))
+				.isInstanceOf(CommentException.class);
 
-        @Test
-        void 좋아요를_한_적이_없을_경우_예외가_발생한다(){
+			verify(memberService).findMemberById(eq(memberId));
+		}
 
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long commentId = 1L;
+		@Test
+		void 좋아요를_한_적이_없을_경우_예외가_발생한다() {
 
-            final Member member = Member.createActivatedMember("xxx", "닉네임", "kakao", true);
-            final Vote vote = Vote.of("imageUrl", member);
-            final Comment comment = Comment.of("댓글", vote, member);
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long commentId = 1L;
 
-            given(memberService.findMemberById(any())).willReturn(member);
-            given(commentRepository.findById(any())).willReturn(Optional.of(comment));
-            given(commentLikeRepository.existsByCommentAndLiker(any(), any())).willReturn(false);
+			final Member member = Member.createActivatedMember("xxx", "닉네임", "kakao", true);
+			final Vote vote = Vote.of("imageUrl", member);
+			final Comment comment = Comment.of("댓글", vote, member);
 
-            // when & then
-            assertThatThrownBy(() -> commentService.unLikeComment(memberPayLoad, commentId))
-                    .isInstanceOf(CommentLikeException.class);
+			given(memberService.findMemberById(any())).willReturn(member);
+			given(commentRepository.findById(any())).willReturn(Optional.of(comment));
+			given(commentLikeRepository.existsByCommentAndLiker(any(), any())).willReturn(false);
 
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> commentService.unLikeComment(memberPayLoad, commentId))
+				.isInstanceOf(CommentLikeException.class);
 
-    @Nested
-    class 댓글_신고_테스트{
+		}
+	}
 
-        @Test
-        void 신고할_댓글이_존재하지_않을_경우_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long commentId = 1L;
+	@Nested
+	class 댓글_신고_테스트 {
 
-            // when & then
-            assertThatThrownBy(() -> commentService.report(memberPayLoad, commentId))
-                    .isInstanceOf(CommentException.class);
+		@Test
+		void 신고할_댓글이_존재하지_않을_경우_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long commentId = 1L;
 
-            verify(memberService).findMemberById(eq(memberId));
-        }
+			// when & then
+			assertThatThrownBy(() -> commentService.report(memberPayLoad, commentId))
+				.isInstanceOf(CommentException.class);
 
-        @Test
-        void 이미_신고를_한_경우_예외가_발생한다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long commentId = 1L;
+			verify(memberService).findMemberById(eq(memberId));
+		}
 
-            final Member member = Member.createActivatedMember("ss", "닉네임", "kakao", true);
-            final Vote vote = Vote.of("imageUrl", member);
-            final Comment comment = Comment.of("내용", vote, member);
-            given(memberService.findMemberById(eq(memberId))).willReturn(member);
-            given(commentRepository.findById(eq(commentId))).willReturn(Optional.of(comment));
-            given(commentReportRepository.existsByCommentAndReporter(any(),any())).willReturn(true);
+		@Test
+		void 이미_신고를_한_경우_예외가_발생한다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long commentId = 1L;
 
-            // when & then
-            assertThatThrownBy(() -> commentService.report(memberPayLoad, commentId))
-                    .isInstanceOf(CommentReportException.class);
+			final Member member = Member.createActivatedMember("ss", "닉네임", "kakao", true);
+			final Vote vote = Vote.of("imageUrl", member);
+			final Comment comment = Comment.of("내용", vote, member);
+			given(memberService.findMemberById(eq(memberId))).willReturn(member);
+			given(commentRepository.findById(eq(commentId))).willReturn(Optional.of(comment));
+			given(commentReportRepository.existsByCommentAndReporter(any(), any())).willReturn(true);
 
-        }
+			// when & then
+			assertThatThrownBy(() -> commentService.report(memberPayLoad, commentId))
+				.isInstanceOf(CommentReportException.class);
 
+		}
+	}
 
-    }
+	// @Nested
+	// class 댓글_대댓글_조회_테스트 {
+	// 	@Test
+	// 	@DisplayName("댓글 ID 를 참조하는 대댓글이 조회 되어야 한다.")
+	// 	void searchReplies() {
+	// 		//given
+	// 		final Long memberId = 1L;
+	// 		long commentId = 10L;
+	// 		final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+	// 		ReplyPageRequest pageRequest = ReplyPageRequest.of(10L, 5);
+	//
+	// 		ArrayList<ReplyResponse> replyResponses = new ArrayList<>();
+	// 		replyResponses.add(
+	// 			createReply(11L, 100L, "testNick1", "testUrl1", true, 0, "test content1"));
+	// 		replyResponses.add(
+	// 			createReply(12L, 100L, "testNick2", "testUrl2", true, 12, "test content2"));
+	// 		replyResponses.add(
+	// 			createReply(13L, 3214L, "testNick3", "testUrl3", true, 13, "test content3"));
+	// 		replyResponses.add(
+	// 			createReply(14L, 50124L, "testNick4", "testUrl4", true, 15, "test content4"));
+	// 		replyResponses.add(
+	// 			createReply(15L, 12312050L, "testNick5", "testUrl5", true, 1, "test content5"));
+	//
+	// 		ReplyPageResponse replyPageResponse = ReplyPageResponse.of(true, replyResponses);
+	//
+	// 		given(commentRepository.existsById(anyLong())).willReturn(true);
+	// 		given(memberService.findMemberById(anyLong())).willReturn(
+	// 			Member.createActivatedMember("testProviderId", "member", "APPLE", true));
+	// 		given(memberService.findBlockedMembers(anyLong())).willReturn(Collections.emptyList());
+	// 		given(commentRepository.searchReplies(anyLong(), anyLong(), any(ReplyPageRequest.class)))
+	// 			.willReturn(replyPageResponse);
+	//
+	// 		//when
+	// 		ReplyPageResponse actual = commentService.searchReplies(memberPayLoad, commentId, pageRequest);
+	//
+	// 		//then
+	// 		assertThat(actual.getComments()).hasSize(5);
+	//
+	// 		then(commentRepository).should(times(1)).existsById(anyLong());
+	// 		then(memberService).should(times(1)).findMemberById(anyLong());
+	// 		then(memberService).should(times(1)).findBlockedMembers(anyLong());
+	// 		then(commentRepository).should(times(1)).searchReplies(anyLong(), anyLong(), any(ReplyPageRequest.class));
+	// 	}
+	//
+	// 	private ReplyResponse createReply(
+	// 		long id, long memberId, String nickName, String imageUrl, boolean liked, int likeCount, String content) {
+	// 		return new ReplyResponse(id, memberId, nickName, imageUrl, liked, likeCount, content, LocalDateTime.now(),
+	// 			LocalDateTime.now());
+	// 	}
+	// }
+
 }

--- a/src/test/java/com/salmalteam/salmal/application/vote/VoteServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/vote/VoteServiceTest.java
@@ -6,8 +6,14 @@ import static org.mockito.BDDMockito.*;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,296 +22,426 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 
+import com.salmalteam.salmal.auth.entity.MemberPayLoad;
 import com.salmalteam.salmal.image.application.ImageUploader;
 import com.salmalteam.salmal.member.application.MemberService;
 import com.salmalteam.salmal.member.entity.Member;
+import com.salmalteam.salmal.member.exception.MemberException;
+import com.salmalteam.salmal.member.exception.MemberExceptionType;
+import com.salmalteam.salmal.presentation.http.vote.SearchTypeConstant;
 import com.salmalteam.salmal.vote.application.VoteService;
+import com.salmalteam.salmal.vote.dto.request.VoteCommentCreateRequest;
+import com.salmalteam.salmal.vote.dto.request.VoteCreateRequest;
+import com.salmalteam.salmal.vote.dto.request.VotePageRequest;
+import com.salmalteam.salmal.vote.dto.response.VotePageResponse;
+import com.salmalteam.salmal.vote.dto.response.VoteResponse;
 import com.salmalteam.salmal.vote.entity.Vote;
-import com.salmalteam.salmal.vote.entity.VoteRepository;
 import com.salmalteam.salmal.vote.entity.VoteBookMarkRepository;
+import com.salmalteam.salmal.vote.entity.VoteRepository;
 import com.salmalteam.salmal.vote.entity.evaluation.VoteEvaluationRepository;
 import com.salmalteam.salmal.vote.entity.evaluation.VoteEvaluationType;
 import com.salmalteam.salmal.vote.entity.report.VoteReportRepository;
-import com.salmalteam.salmal.vote.dto.request.VoteCommentCreateRequest;
-import com.salmalteam.salmal.vote.dto.request.VoteCreateRequest;
-import com.salmalteam.salmal.member.exception.MemberException;
-import com.salmalteam.salmal.member.exception.MemberExceptionType;
 import com.salmalteam.salmal.vote.exception.VoteException;
 import com.salmalteam.salmal.vote.exception.bookmark.VoteBookmarkException;
-import com.salmalteam.salmal.auth.entity.MemberPayLoad;
 
 @ExtendWith(MockitoExtension.class)
 class VoteServiceTest {
 
-    @InjectMocks
-    VoteService voteService;
-    @Mock
-    MemberService memberService;
-    @Mock
-    VoteRepository voteRepository;
+	@InjectMocks
+	VoteService voteService;
+	@Mock
+	MemberService memberService;
+	@Mock
+	VoteRepository voteRepository;
 
-    @Mock
-    VoteBookMarkRepository voteBookMarkRepository;
-    @Mock
-    VoteEvaluationRepository voteEvaluationRepository;
-    @Mock
-    VoteReportRepository voteReportRepository;
-    @Mock
-    ImageUploader imageUploader;
+	@Mock
+	VoteBookMarkRepository voteBookMarkRepository;
+	@Mock
+	VoteEvaluationRepository voteEvaluationRepository;
+	@Mock
+	VoteReportRepository voteReportRepository;
+	@Mock
+	ImageUploader imageUploader;
 
-    @Nested
-    class 투표_업로드_테스트 {
-        @Test
-        void 이미지_업로더를_통해_업로드후_요청에_해당하는_회원을_찾은_뒤_저장한다() throws IOException {
-            // given
-            final Long memberId = 1L;
-            final String name = "imageFile";
-            final String fileName = "testImage.jpg";
-            final String filePath = "src/test/resources/testImages/".concat(fileName);
-            final FileInputStream fileInputStream = new FileInputStream(filePath);
-            final String contentType = "image/jpeg";
-            final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final VoteCreateRequest voteCreateRequest = new VoteCreateRequest(multipartFile);
+	@Nested
+	class 투표_업로드_테스트 {
+		@Test
+		void 이미지_업로더를_통해_업로드후_요청에_해당하는_회원을_찾은_뒤_저장한다() throws IOException {
+			// given
+			final Long memberId = 1L;
+			final String name = "imageFile";
+			final String fileName = "testImage.jpg";
+			final String filePath = "src/test/resources/testImages/".concat(fileName);
+			final FileInputStream fileInputStream = new FileInputStream(filePath);
+			final String contentType = "image/jpeg";
+			final MockMultipartFile multipartFile = new MockMultipartFile(name, fileName, contentType, fileInputStream);
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final VoteCreateRequest voteCreateRequest = new VoteCreateRequest(multipartFile);
 
-            // when
-            voteService.register(memberPayLoad, voteCreateRequest);
+			// when
+			voteService.register(memberPayLoad, voteCreateRequest);
 
-            // then
-            verify(imageUploader, times(1)).uploadImage(any());
-            verify(memberService, times(1)).findMemberById(any());
-            verify(voteRepository, times(1)).save(any());
-        }
-    }
+			// then
+			verify(imageUploader, times(1)).uploadImage(any());
+			verify(memberService, times(1)).findMemberById(any());
+			verify(voteRepository, times(1)).save(any());
+		}
+	}
 
-    @Nested
-    class 투표_평가_테스트 {
+	@Nested
+	class 투표_평가_테스트 {
 
-        @Test
-        void 평가를_할_투표가_존재하지_않는다면_예외를_발생시킨다() {
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
-            final String voteEvaluationTypeStr = "LIKE";
-            final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluationTypeStr);
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
+		@Test
+		void 평가를_할_투표가_존재하지_않는다면_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
+			final String voteEvaluationTypeStr = "LIKE";
+			final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluationTypeStr);
+			given(memberService.findMemberById(eq(memberId))).willReturn(
+				Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
+			given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
-            // when & then
-            assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluationType))
-                    .isInstanceOf(VoteException.class);
-        }
+			// when & then
+			assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluationType))
+				.isInstanceOf(VoteException.class);
+		}
 
-        @Test
-        void 이미_동일한_타입의_투표를_이행한_적이_있다면_예외를_발생시킨다() {
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
-            final String voteEvaluationTypeStr = "LIKE";
-            final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluationTypeStr);
+		@Test
+		void 이미_동일한_타입의_투표를_이행한_적이_있다면_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
+			final String voteEvaluationTypeStr = "LIKE";
+			final VoteEvaluationType voteEvaluationType = VoteEvaluationType.from(voteEvaluationTypeStr);
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true))));
-            given(voteEvaluationRepository.existsByEvaluatorAndVoteAndVoteEvaluationType(any(), any(), any())).willReturn(true);
+			given(memberService.findMemberById(eq(memberId))).willReturn(
+				Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
+			given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(
+				Vote.of("imageUrl", Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true))));
+			given(
+				voteEvaluationRepository.existsByEvaluatorAndVoteAndVoteEvaluationType(any(), any(), any())).willReturn(
+				true);
 
-            // when & then
-            assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluationType))
-                    .isInstanceOf(VoteException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> voteService.evaluate(memberPayLoad, voteId, voteEvaluationType))
+				.isInstanceOf(VoteException.class);
+		}
+	}
 
-    @Nested
-    class 투표_북마킹_테스트 {
+	@Nested
+	class 투표_북마킹_테스트 {
 
-        @Test
-        void 북마크_할_투표가_존재하지_않는다면_예외를_발생시킨다() {
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
+		@Test
+		void 북마크_할_투표가_존재하지_않는다면_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
+			given(memberService.findMemberById(eq(memberId))).willReturn(
+				Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
+			given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
-            // when & then
-            assertThatThrownBy(() -> voteService.bookmark(memberPayLoad, voteId))
-                    .isInstanceOf(VoteException.class);
-        }
+			// when & then
+			assertThatThrownBy(() -> voteService.bookmark(memberPayLoad, voteId))
+				.isInstanceOf(VoteException.class);
+		}
 
-        @Test
-        void 이미_북마크한_투표일_경우_예외를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
-            final Member member = Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true);
+		@Test
+		void 이미_북마크한_투표일_경우_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
+			final Member member = Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true);
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(member);
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", member)));
-            given(voteBookMarkRepository.existsByVoteAndBookmaker(any(), any())).willReturn(true);
+			given(memberService.findMemberById(eq(memberId))).willReturn(member);
+			given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", member)));
+			given(voteBookMarkRepository.existsByVoteAndBookmaker(any(), any())).willReturn(true);
 
-            // when & then
-            assertThatThrownBy(() -> voteService.bookmark(memberPayLoad, voteId))
-                    .isInstanceOf(VoteBookmarkException.class);
+			// when & then
+			assertThatThrownBy(() -> voteService.bookmark(memberPayLoad, voteId))
+				.isInstanceOf(VoteBookmarkException.class);
 
-        }
+		}
 
-    }
+	}
 
-    @Nested
-    class 북마크_취소_테스트{
-        @Test
-        void 북마크를_취소할_투표가_존재하지_않는다면_예외를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
+	@Nested
+	class 북마크_취소_테스트 {
+		@Test
+		void 북마크를_취소할_투표가_존재하지_않는다면_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
 
-            // when & then
-            assertThatThrownBy(() -> voteService.cancelBookmark(memberPayLoad, voteId))
-                    .isInstanceOf(VoteException.class);
+			// when & then
+			assertThatThrownBy(() -> voteService.cancelBookmark(memberPayLoad, voteId))
+				.isInstanceOf(VoteException.class);
 
-            verify(memberService, times(1)).findMemberById(any());
-        }
-    }
+			verify(memberService, times(1)).findMemberById(any());
+		}
+	}
 
-    @Nested
-    class 투표_신고_테스트{
+	@Nested
+	class 투표_신고_테스트 {
 
-        @Test
-        void 존재하지_않는_회원의_요청일경우_예외를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
+		@Test
+		void 존재하지_않는_회원의_요청일경우_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
 
-            given(memberService.findMemberById(eq(memberId))).willThrow(new MemberException(MemberExceptionType.NOT_FOUND));
+			given(memberService.findMemberById(eq(memberId))).willThrow(
+				new MemberException(MemberExceptionType.NOT_FOUND));
 
-            // when & then
-            assertThatThrownBy(() -> voteService.report(memberPayLoad, voteId))
-                    .isInstanceOf(MemberException.class);
-        }
+			// when & then
+			assertThatThrownBy(() -> voteService.report(memberPayLoad, voteId))
+				.isInstanceOf(MemberException.class);
+		}
 
-        @Test
-        void 신고할_투표가_존재하지_않는다면_예외를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
+		@Test
+		void 신고할_투표가_존재하지_않는다면_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
+			given(memberService.findMemberById(eq(memberId))).willReturn(
+				Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
+			given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
-            // when & then
-            assertThatThrownBy(() -> voteService.report(memberPayLoad, voteId))
-                    .isInstanceOf(VoteException.class);
-        }
+			// when & then
+			assertThatThrownBy(() -> voteService.report(memberPayLoad, voteId))
+				.isInstanceOf(VoteException.class);
+		}
 
-        @Test
-        void 이미_해당_투표를_신고했을_경우_예외를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
+		@Test
+		void 이미_해당_투표를_신고했을_경우_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(Vote.of("imageUrl", Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true))));
-            given(voteReportRepository.existsByVoteAndReporter(any(), any())).willReturn(true);
+			given(memberService.findMemberById(eq(memberId))).willReturn(
+				Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
+			given(voteRepository.findById(eq(voteId))).willReturn(Optional.ofNullable(
+				Vote.of("imageUrl", Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true))));
+			given(voteReportRepository.existsByVoteAndReporter(any(), any())).willReturn(true);
 
-            // when & then
-            assertThatThrownBy(() -> voteService.report(memberPayLoad, voteId))
-                    .isInstanceOf(VoteException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> voteService.report(memberPayLoad, voteId))
+				.isInstanceOf(VoteException.class);
+		}
+	}
 
-    @Nested
-    class 투표_댓글_생성_테스트{
+	@Nested
+	class 투표_댓글_생성_테스트 {
 
-        @Test
-        void 존재하지_않는_회원의_요청일경우_예외를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
-            final String content = "댓글입니다";
-            final VoteCommentCreateRequest voteCommentCreateRequest = new VoteCommentCreateRequest(content);
+		@Test
+		void 존재하지_않는_회원의_요청일경우_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
+			final String content = "댓글입니다";
+			final VoteCommentCreateRequest voteCommentCreateRequest = new VoteCommentCreateRequest(content);
 
-            given(memberService.findMemberById(eq(memberId))).willThrow(new MemberException(MemberExceptionType.NOT_FOUND));
+			given(memberService.findMemberById(eq(memberId))).willThrow(
+				new MemberException(MemberExceptionType.NOT_FOUND));
 
-            // when & then
-            assertThatThrownBy(() -> voteService.comment(memberPayLoad, voteId, voteCommentCreateRequest))
-                    .isInstanceOf(MemberException.class);
-        }
+			// when & then
+			assertThatThrownBy(() -> voteService.comment(memberPayLoad, voteId, voteCommentCreateRequest))
+				.isInstanceOf(MemberException.class);
+		}
 
-        @Test
-        void 댓글을_추가할_투표가_존재하지_않는다면_예외를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
-            final String content = "댓글입니다";
-            final VoteCommentCreateRequest voteCommentCreateRequest = new VoteCommentCreateRequest(content);
+		@Test
+		void 댓글을_추가할_투표가_존재하지_않는다면_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
+			final String content = "댓글입니다";
+			final VoteCommentCreateRequest voteCommentCreateRequest = new VoteCommentCreateRequest(content);
 
-            given(memberService.findMemberById(eq(memberId))).willReturn(Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
-            given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
+			given(memberService.findMemberById(eq(memberId))).willReturn(
+				Member.createActivatedMember("LLLLLLL", "닉네임", "KAKAO", true));
+			given(voteRepository.findById(eq(voteId))).willReturn(Optional.empty());
 
-            // when & then
-            assertThatThrownBy(() -> voteService.comment(memberPayLoad, voteId, voteCommentCreateRequest))
-                    .isInstanceOf(VoteException.class);
-        }
+			// when & then
+			assertThatThrownBy(() -> voteService.comment(memberPayLoad, voteId, voteCommentCreateRequest))
+				.isInstanceOf(VoteException.class);
+		}
 
-    }
+	}
 
-    @Nested
-    class 투표_조회_테스트{
-        @Test
-        void 투표가_존재하지_않으면_오류를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
+	@Nested
+	class 투표_조회_테스트 {
+		@Test
+		void 투표가_존재하지_않으면_오류를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
 
-            given(voteRepository.existsById(eq(voteId))).willReturn(false);
+			given(voteRepository.existsById(eq(voteId))).willReturn(false);
 
-            // when & then
-            assertThatThrownBy(() -> voteService.search(memberPayLoad, voteId))
-                    .isInstanceOf(VoteException.class);
-        }
-    }
+			// when & then
+			assertThatThrownBy(() -> voteService.search(memberPayLoad, voteId))
+				.isInstanceOf(VoteException.class);
+		}
 
-    @Nested
-    class 투표_댓글_목록_조회_테스트{
-        @Test
-        void 댓글_목록을_조회할_투표가_존재하지_않으면_예외를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
-            given(voteRepository.existsById(any())).willReturn(false);
+		@Test
+		@DisplayName("투표 리스트가 조회되어야 한다.")
+		void searchList() {
+			//given
+			final Long memberId = 105L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
 
-            // when & then 
-            assertThatThrownBy(() -> voteService.search(memberPayLoad, voteId))
-                    .isInstanceOf(VoteException.class);
-        }
-    }
+			VotePageRequest pageRequest = new VotePageRequest(21L, 100, 8, "HOME");
+			List<VoteResponse> voteResponses = new ArrayList<>();
+			voteResponses.add(createVoteResponse(1L, 100L, "testUrl.com", "testNickName1", "memberImageUrl", 1, 20035,
+				20000, 50));
+			voteResponses.add(createVoteResponse(2L, 23123L, "testUrl.com", "testNickName2", "memberImageUrl", 2, 20035,
 
-    @Nested
-    class 투표_평가_취소_테스트{
-        @Test
-        void 투표가_존재하지_않으면_오류를_발생시킨다(){
-            // given
-            final Long memberId = 1L;
-            final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
-            final Long voteId = 1L;
+				20000, 50));
+			voteResponses.add(
+				createVoteResponse(3L, 410232140L, "testUrl.com", "testNickName3", "memberImageUrl", 6, 20035,
+					20000, 50));
+			voteResponses.add(
+				createVoteResponse(4L, 101231250L, "testUrl.com", "testNickName4", "memberImageUrl", 5, 20035,
+					20000, 50));
+			voteResponses.add(
+				createVoteResponse(5L, 102130L, "testUrl.com", "testNickName5", "memberImageUrl", 5, 20035,
+					20000, 50));
+			voteResponses.add(createVoteResponse(6L, 41200L, "testUrl.com", "testNickName6", "memberImageUrl", 4, 20035,
+				20000, 50));
+			voteResponses.add(createVoteResponse(7L, 2100L, "testUrl.com", "testNickName7", "memberImageUrl", 10, 20035,
+				20000, 50));
+			voteResponses.add(
+				createVoteResponse(8L, 13215006L, "testUrl.com", "testNickName8", "memberImageUrl", 10, 20035,
+					20000, 50));
 
-            // when & then
-            assertThatThrownBy(() -> voteService.cancelEvaluation(memberPayLoad, voteId))
-                    .isInstanceOf(VoteException.class);
+			VotePageResponse votePageResponse = VotePageResponse.of(true, voteResponses);
 
-            verify(memberService, times(1)).findMemberById(any());
-        }
-    }
+			given(memberService.findBlockedMembers(anyLong())).willReturn(Collections.emptyList());
+			given(voteRepository.searchList(memberId, pageRequest, SearchTypeConstant.HOME)).willReturn(
+				votePageResponse);
+
+			//when
+			VotePageResponse actual = voteService.searchList(memberPayLoad, pageRequest, SearchTypeConstant.HOME);
+
+
+			//then
+			assertThat(actual.getVotes()).hasSize(8);
+
+			then(memberService)
+				.should(times(1)).
+				findBlockedMembers(anyLong());
+			then(voteRepository)
+				.should(times(1))
+				.searchList(anyLong(), any(VotePageRequest.class), any(SearchTypeConstant.class));
+		}
+
+		@Test
+		@DisplayName("투표 조회 시 차단한 회원의 투표는 조회되지 않는다.")
+		void searchListExcludeBlockedMembers() throws Exception {
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+
+			VotePageRequest pageRequest = new VotePageRequest(21L, 100, 8, "HOME");
+			List<VoteResponse> voteResponses = new ArrayList<>();
+			voteResponses.add(createVoteResponse(1L, 100L, "testUrl.com", "testNickName1", "memberImageUrl", 1, 20035,
+				20000, 50));
+			voteResponses.add(createVoteResponse(2L, 23123L, "testUrl.com", "testNickName2", "memberImageUrl", 2, 20035,
+				20000, 50));
+			voteResponses.add(
+				createVoteResponse(3L, 410232140L, "testUrl.com", "testNickName3", "memberImageUrl", 6, 20035,
+					20000, 50));
+			voteResponses.add(
+				createVoteResponse(4L, 101231250L, "testUrl.com", "testNickName4", "memberImageUrl", 5, 20035,
+					20000, 50));
+			voteResponses.add(
+				createVoteResponse(5L, 102130L, "testUrl.com", "testNickName5", "memberImageUrl", 5, 20035,
+					20000, 50));
+			voteResponses.add(createVoteResponse(6L, 7L, "testUrl.com", "testNickName6", "memberImageUrl", 4, 20035,
+				20000, 50));
+			voteResponses.add(createVoteResponse(7L, 7L, "testUrl.com", "testNickName7", "memberImageUrl", 10, 20035,
+				20000, 50));
+			voteResponses.add(
+				createVoteResponse(8L, 13215006L, "testUrl.com", "testNickName8", "memberImageUrl", 10, 20035,
+					20000, 50));
+
+			VotePageResponse votePageResponse = VotePageResponse.of(true, voteResponses);
+
+			ArrayList<Long> ids = new ArrayList<>();
+			ids.add(101231250L);
+			ids.add(7L);
+
+			given(memberService.findBlockedMembers(anyLong()))
+				.willReturn(ids);
+			given(voteRepository.searchList(memberId, pageRequest, SearchTypeConstant.HOME))
+				.willReturn(votePageResponse);
+
+			//when
+			VotePageResponse actual = voteService.searchList(memberPayLoad, pageRequest, SearchTypeConstant.HOME);
+
+			//then
+			assertThat(actual.getVotes()).hasSize(5);
+
+			then(memberService)
+				.should(times(1)).
+				findBlockedMembers(anyLong());
+			then(voteRepository)
+				.should(times(1))
+				.searchList(anyLong(), any(VotePageRequest.class), any(SearchTypeConstant.class));
+
+		}
+
+		private VoteResponse createVoteResponse(long id, long memberId, String imageUrl, String testNickName,
+			String memberIamgeUrl, int commentCount, int likeCount, int disLikeCount, int totalEvaluationCnt) {
+			return new VoteResponse(id, memberId, imageUrl, testNickName, memberIamgeUrl, commentCount, likeCount,
+				disLikeCount, totalEvaluationCnt, BigDecimal.valueOf(50), BigDecimal.valueOf(50), LocalDateTime.now(),
+				false, "NONE");
+		}
+	}
+
+	@Nested
+	class 투표_댓글_목록_조회_테스트 {
+		@Test
+		void 댓글_목록을_조회할_투표가_존재하지_않으면_예외를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
+			given(voteRepository.existsById(any())).willReturn(false);
+
+			// when & then
+			assertThatThrownBy(() -> voteService.search(memberPayLoad, voteId))
+				.isInstanceOf(VoteException.class);
+		}
+	}
+
+	@Nested
+	class 투표_평가_취소_테스트 {
+		@Test
+		void 투표가_존재하지_않으면_오류를_발생시킨다() {
+			// given
+			final Long memberId = 1L;
+			final MemberPayLoad memberPayLoad = MemberPayLoad.from(memberId);
+			final Long voteId = 1L;
+
+			// when & then
+			assertThatThrownBy(() -> voteService.cancelEvaluation(memberPayLoad, voteId))
+				.isInstanceOf(VoteException.class);
+
+			verify(memberService, times(1)).findMemberById(any());
+		}
+	}
 
 }

--- a/src/test/java/com/salmalteam/salmal/config/DataJpaTestConfig.java
+++ b/src/test/java/com/salmalteam/salmal/config/DataJpaTestConfig.java
@@ -1,0 +1,46 @@
+package com.salmalteam.salmal.config;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.salmalteam.salmal.comment.entity.CommentRepositoryCustomImpl;
+import com.salmalteam.salmal.member.entity.MemberBlockedRepositoryCustomImpl;
+import com.salmalteam.salmal.member.entity.MemberRepositoryCustomImpl;
+import com.salmalteam.salmal.vote.entity.VoteRepositoryCustomImpl;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class DataJpaTestConfig {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+
+	@Bean
+	public MemberBlockedRepositoryCustomImpl memberBlockedRepositoryCustom() {
+		return new MemberBlockedRepositoryCustomImpl(jpaQueryFactory());
+	}
+
+	@Bean
+	public CommentRepositoryCustomImpl commentRepositoryCustom() {
+		return new CommentRepositoryCustomImpl(jpaQueryFactory());
+	}
+
+	@Bean
+	public MemberRepositoryCustomImpl memberRepositoryCustom() {
+		return new MemberRepositoryCustomImpl(jpaQueryFactory());
+	}
+
+	@Bean
+	public VoteRepositoryCustomImpl voteRepositoryCustom() {
+		return new VoteRepositoryCustomImpl(jpaQueryFactory());
+	}
+}

--- a/src/test/java/com/salmalteam/salmal/member/entity/MemberBlockedRepositoryTest.java
+++ b/src/test/java/com/salmalteam/salmal/member/entity/MemberBlockedRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.salmalteam.salmal.member.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.salmalteam.salmal.config.DataJpaTestConfig;
+
+@DataJpaTest
+@Import(DataJpaTestConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MemberBlockedRepositoryTest {
+
+	@Autowired
+	MemberBlockedRepository blockedRepository;
+	@Autowired
+	MemberRepository memberRepository;
+
+	@BeforeEach
+	void setUp() {
+		memberRepository.save(Member.createActivatedMember("test1", "testNickName1", "APPLE", true));
+		memberRepository.save(Member.createActivatedMember("test2", "testNickName2", "APPLE", true));
+		memberRepository.save(Member.createActivatedMember("test3", "testNickName3", "KAKAO", false));
+		memberRepository.save(Member.createActivatedMember("test3", "testNickName4", "KAKAO", false));
+	}
+
+	@Test
+	@DisplayName("회원 아이디를 받아 차단한 회원의 아이디 리스트를 조회해야 한다.")
+	void findBlockedMembers() {
+		//given
+		List<Member> members = memberRepository.findAll();
+		Member member1 = members.get(0);
+		Member member2 = members.get(1);
+		Member member3 = members.get(2);
+		Member member4 = members.get(3);
+
+		blockedRepository.save(MemberBlocked.of(member1, member2));
+		blockedRepository.save(MemberBlocked.of(member1, member3));
+		blockedRepository.save(MemberBlocked.of(member1, member4));
+		blockedRepository.save(MemberBlocked.of(member2, member3));
+
+		//when
+		List<Long> blockedMembers = blockedRepository.findTargetMemberIdByMemberId(member1.getId());
+
+		//then
+		assertThat(blockedMembers).hasSize(3);
+
+	}
+}

--- a/src/test/java/com/salmalteam/salmal/member/entity/MemberBlockedRepositoryTest.java
+++ b/src/test/java/com/salmalteam/salmal/member/entity/MemberBlockedRepositoryTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -16,7 +15,6 @@ import com.salmalteam.salmal.config.DataJpaTestConfig;
 
 @DataJpaTest
 @Import(DataJpaTestConfig.class)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MemberBlockedRepositoryTest {
 
 	@Autowired


### PR DESCRIPTION
# 📌 연관 이슈
- #131 

# 🧑‍💻 작업 내역
- [x] 차단한 회원 아이디를 전체 조회하는 기능 구현
- [x] 차단한 회원의 투표는 조회가 되지않게 변경
- [x] 차단한 회원의 댓글는 조회가 되지않게 변경
- [x] 차단한 회원의 대댓글(reply)는 조회가 되지않게 변경

# 📚 참고 자료 (Optional)
`flyway` 의존성 제거
`MemberRepository` 가 `Repository` 를 상속하는 것에서 `JpaRepository` 를 상속하게 변경하였습니다.

# 🧐 더 나아가야할 점 혹은 고민 (Optional)
차단한 회원을 조회하는 기능의 단위테스트와 서비스단 단위테스트는 작성 하였으나 다른 필터링이 적용된 기능의 api 단위 테스트를 추가적으로 작성하지 않았습니다. 추후 통합 테스트나 시나리오 기반의 테스트 통해서 엔드포인트 테스트를 하는것이 테스트 효율성에 더 좋을것 같아서 보류 해두었습니다.
