### PR TITLE
Refactoring:알림조회 변경

### DIFF
--- a/src/main/java/com/salmalteam/salmal/comment/dto/response/ReplayCommentDto.java
+++ b/src/main/java/com/salmalteam/salmal/comment/dto/response/ReplayCommentDto.java
@@ -1,5 +1,9 @@
 package com.salmalteam.salmal.comment.dto.response;
 
+import com.salmalteam.salmal.comment.entity.Comment;
+import com.salmalteam.salmal.member.entity.Member;
+import com.salmalteam.salmal.vote.entity.Vote;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,12 +11,27 @@ import lombok.Getter;
 @Getter
 public class ReplayCommentDto {
 	private final Long commentOwnerId;
-	private final Long commenterId;
+	private final Long replyerId;
 	private final Long commentId;
 	private final String nickName;
 	private final String content;
+	private final String commenterImageUrl;
+	private final String VoteImageUrl;
+
+	public static ReplayCommentDto createNotificationType(Member replyer, Member commenterOwner, Comment comment, Comment reply,
+		Vote vote) {
+		return new ReplayCommentDto(
+			commenterOwner.getId(), //알림 타켓 ID
+			replyer.getId(), //대댓글 작성자
+			comment.getId(), //대댓글을 작성한 댓글 ID
+			replyer.getNickName().getValue(), //대댓글 작성자 ID
+			reply.getContent().getValue(),  //대댓글 내용
+			replyer.getMemberImage().getImageUrl(), //대댓글 작성자 이미지
+			vote.getVoteImage().getImageUrl() //대댓글 작성한 투표의 이미지
+		);
+	}
 
 	public boolean isSameCommenter() {
-		return commentOwnerId.equals(commenterId);
+		return commentOwnerId.equals(replyerId);
 	}
 }

--- a/src/main/java/com/salmalteam/salmal/comment/dto/response/ReplayCommentDto.java
+++ b/src/main/java/com/salmalteam/salmal/comment/dto/response/ReplayCommentDto.java
@@ -15,7 +15,7 @@ public class ReplayCommentDto {
 	private final Long commentId;
 	private final String nickName;
 	private final String content;
-	private final String commenterImageUrl;
+	private final String replyerImageUrl;
 	private final String VoteImageUrl;
 
 	public static ReplayCommentDto createNotificationType(Member replyer, Member commenterOwner, Comment comment, Comment reply,

--- a/src/main/java/com/salmalteam/salmal/comment/entity/CommentRepository.java
+++ b/src/main/java/com/salmalteam/salmal/comment/entity/CommentRepository.java
@@ -11,7 +11,8 @@ import org.springframework.data.repository.query.Param;
 public interface CommentRepository extends Repository<Comment, Long>, CommentRepositoryCustom {
 	Comment save(Comment comment);
 	void delete(Comment comment);
-	Optional<Comment> findById(Long id);
+	@Query("select c from Comment c join fetch c.commenter join fetch c.vote where c.id =:id")
+	Optional<Comment> findById(@Param("id") Long id);
 	boolean existsById(Long id);
 	List<Comment> findAllByCommenter_Id(Long commenterId);
 	List<Comment> findALlByCommenter_idAndCommentType(Long commenterId, CommentType commentType);

--- a/src/main/java/com/salmalteam/salmal/comment/entity/Content.java
+++ b/src/main/java/com/salmalteam/salmal/comment/entity/Content.java
@@ -1,15 +1,18 @@
 package com.salmalteam.salmal.comment.entity;
 
-import com.salmalteam.salmal.comment.exception.CommentException;
-import com.salmalteam.salmal.comment.exception.CommentExceptionType;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+import com.salmalteam.salmal.comment.exception.CommentException;
+import com.salmalteam.salmal.comment.exception.CommentExceptionType;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Content {
 
     private static final int MAX_LENGTH = 100;

--- a/src/main/java/com/salmalteam/salmal/member/application/MemberService.java
+++ b/src/main/java/com/salmalteam/salmal/member/application/MemberService.java
@@ -179,7 +179,7 @@ public class MemberService {
 
 		validateUpdateAuthority(member, targetMember);
 
-		member.updateImage(MemberImage.getMemberImageUrl());
+		member.updateImage(MemberImage.getDefaultMemberImageUrl());
 		memberRepository.save(member);
 	}
 

--- a/src/main/java/com/salmalteam/salmal/member/entity/MemberImage.java
+++ b/src/main/java/com/salmalteam/salmal/member/entity/MemberImage.java
@@ -1,10 +1,10 @@
 package com.salmalteam.salmal.member.entity;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,8 +25,11 @@ public class MemberImage {
         return new MemberImage(MEMBER_IMAGE_URL);
     }
 
-    public static String getMemberImageUrl(){
+    public static String getDefaultMemberImageUrl(){
         return MEMBER_IMAGE_URL;
     }
 
+    public String getImageUrl(){
+        return imageUrl;
+    }
 }

--- a/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
+++ b/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
@@ -17,7 +17,7 @@ public class NotificationDto {
 	private final Type type;
 	private final String message;
 	private final boolean isRead;
-	@JsonFormat(pattern = "yy-MM-dd'T'HH:mm")
+	@JsonFormat(pattern = "yy-MM-dd'T'HH:mm:ss")
 	private final LocalDateTime createAt;
 	private final String memberImageUrl;
 	private final String imageUrl;

--- a/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
+++ b/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
@@ -16,11 +16,15 @@ public class NotificationDto {
 	private final Long markId;
 	private final Type type;
 	private final String message;
+	private final boolean isRead;
 	@JsonFormat(pattern = "yy-MM-ddTHH:mm")
 	private final LocalDateTime createAt;
 
+	private final String memberImageUrl;
+	private final String imageUrl;
+
 	public static NotificationDto create(Notification notification) {
 		return new NotificationDto(notification.getUuid(), notification.getMarkId(), notification.getType(),
-			notification.getMessage(), notification.getCreatedAt());
+			notification.getMessage(), notification.isRead(), notification.getCreatedAt(), notification.getMemberImageUrl(), notification.getMemberImageUrl());
 	}
 }

--- a/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
+++ b/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
@@ -24,6 +24,6 @@ public class NotificationDto {
 
 	public static NotificationDto create(Notification notification) {
 		return new NotificationDto(notification.getUuid(), notification.getMarkId(), notification.getType(),
-			notification.getMessage(), notification.isRead(), notification.getCreatedAt(), notification.getMemberImageUrl(), notification.getMemberImageUrl());
+			notification.getMessage(), notification.isRead(), notification.getCreatedAt(), notification.getMemberImageUrl(), notification.getMarkContentImageUrl());
 	}
 }

--- a/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
+++ b/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
@@ -17,9 +17,8 @@ public class NotificationDto {
 	private final Type type;
 	private final String message;
 	private final boolean isRead;
-	@JsonFormat(pattern = "yy-MM-ddTHH:mm")
+	@JsonFormat(pattern = "yy-MM-dd'T'HH:mm")
 	private final LocalDateTime createAt;
-
 	private final String memberImageUrl;
 	private final String imageUrl;
 

--- a/src/main/java/com/salmalteam/salmal/notification/entity/Notification.java
+++ b/src/main/java/com/salmalteam/salmal/notification/entity/Notification.java
@@ -32,9 +32,13 @@ public class Notification extends BaseCreatedTimeEntity {
 	@Enumerated(value = EnumType.STRING)
 	private Type type;
 	private boolean isRead;
+	private String memberImageUrl;
+	private String markContentImageUrl;
 
-	public static Notification createNewReplyType(Long memberId, Long markId, UUID uuid, String message) {
-		return new Notification(null, memberId, uuid.toString(), message, markId, Type.REPLY, false);
+	public static Notification createNewReplyType(Long memberId, Long markId, UUID uuid, String message,
+		String memberImageUrl, String markContentImageUrl) {
+		return new Notification(null, memberId, uuid.toString(), message, markId, Type.REPLY, false, memberImageUrl,
+			markContentImageUrl);
 	}
 
 	public void read() {

--- a/src/main/java/com/salmalteam/salmal/notification/service/NotificationService.java
+++ b/src/main/java/com/salmalteam/salmal/notification/service/NotificationService.java
@@ -54,7 +54,8 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public MessageSpec save(Long targetId, Long issuedContentId, String nickName, String content, Long memberId) {
+	public MessageSpec save(Long targetId, Long issuedContentId, String nickName, String content, Long memberId,
+		String memberImageUrl, String contentImageUrl) {
 
 		String message = String.format("%s님의 답댓글:%s", nickName, content);
 
@@ -63,7 +64,8 @@ public class NotificationService {
 			.orElse("token");
 
 		Notification notification = notificationRepository.save(
-			Notification.createNewReplyType(memberId, issuedContentId, uuidGenerator.generate(), message));
+			Notification.createNewReplyType(memberId, issuedContentId, uuidGenerator.generate(), message,
+				memberImageUrl, contentImageUrl));
 
 		HashMap<String, String> data = new HashMap<>();
 

--- a/src/main/java/com/salmalteam/salmal/presentation/http/comment/CommentController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/http/comment/CommentController.java
@@ -95,7 +95,7 @@ public class CommentController {
 		MessageSpec messageSpec = notificationService.save(
 			replayComment.getCommentOwnerId(), replayComment.getCommentId(),
 			replayComment.getNickName(), replayComment.getContent(), replayComment.getReplyerId(),
-			replayComment.getReplyerImageUrl(), replayComment.getReplyerImageUrl());
+			replayComment.getReplyerImageUrl(), replayComment.getVoteImageUrl());
 		notificationPublisher.pub(messageSpec);
 	}
 

--- a/src/main/java/com/salmalteam/salmal/presentation/http/comment/CommentController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/http/comment/CommentController.java
@@ -94,7 +94,8 @@ public class CommentController {
 		}
 		MessageSpec messageSpec = notificationService.save(
 			replayComment.getCommentOwnerId(), replayComment.getCommentId(),
-			replayComment.getNickName(),replayComment.getContent(), replayComment.getCommenterId());
+			replayComment.getNickName(), replayComment.getContent(), replayComment.getReplyerId(),
+			replayComment.getReplyerImageUrl(), replayComment.getReplyerImageUrl());
 		notificationPublisher.pub(messageSpec);
 	}
 

--- a/src/main/java/com/salmalteam/salmal/vote/entity/VoteImage.java
+++ b/src/main/java/com/salmalteam/salmal/vote/entity/VoteImage.java
@@ -1,13 +1,15 @@
 package com.salmalteam.salmal.vote.entity;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class VoteImage {
 
     @Column(name = "image_url")

--- a/src/test/java/com/salmalteam/salmal/presentation/comment/CommentControllerTest.java
+++ b/src/test/java/com/salmalteam/salmal/presentation/comment/CommentControllerTest.java
@@ -249,7 +249,7 @@ class CommentControllerTest extends PresentationTest {
             final Long commentId = 1L;
             final String content = "이 댓글에 동의합니다!";
             final CommentReplyCreateRequest commentReplyCreateRequest = new CommentReplyCreateRequest(content);
-            ReplayCommentDto replayCommentDto = new ReplayCommentDto(100L, 20L, 556L, "kim", "content");
+            ReplayCommentDto replayCommentDto = new ReplayCommentDto(100L, 20L, 556L, "kim", "content","url","url");
             given(commentService.replyComment(any(),anyLong(),any()))
                 .willReturn(replayCommentDto);
             mockingForAuthorization();

--- a/src/test/java/com/salmalteam/salmal/presentation/comment/CommentControllerTest.java
+++ b/src/test/java/com/salmalteam/salmal/presentation/comment/CommentControllerTest.java
@@ -276,7 +276,8 @@ class CommentControllerTest extends PresentationTest {
             ));
 
             verify(commentService, times(1)).replyComment(any(), any(), any());
-            verify(notificationService, times(1)).save(anyLong(),anyLong(),anyString(),anyString(),anyLong());
+            verify(notificationService, times(1)).save(anyLong(),anyLong(),anyString(),anyString(),anyLong(),
+				anyString(), anyString());
             verify(fcmClient, times(1)).pub(any());
 
         }


### PR DESCRIPTION
# 📌 연관 이슈
- #153 
# 🧑‍💻 작업 내역
- [x] 알림조회 응답 API 스펙 변경

# 📚 참고 자료 (Optional)
- 임베디드로 구현된 엔티티 필드 `getter` 추가
- 기존 대댓글 저장 시 부모댓글 `commet` 조회할 때 그냥 일반 조회 했었는데 부모댓글이 가지고 있는 투표정보 `vote` 와 작성 회원 `member` 를 같이 페치 조인는 쿼리로 변경하였습니다. 이유는 회원의 이미지 url 과 투표 이미지 url 값이 추가적으로 필요해서 페치조인으로 한번에 가져와서 사용하기 위해서 입니다.
- 그외 응답 API 생성시간 `createdAt` 포맷 알맞게 변경 , 대댓글 주인을 `commeter` 에서 `replyer` 로 변경

# 🧐 더 나아가야할 점 혹은 고민 (Optional)
