### PR TITLE
Refactoring:notification data

### DIFF
--- a/src/main/java/com/salmalteam/salmal/comment/dto/response/ReplayCommentDto.java
+++ b/src/main/java/com/salmalteam/salmal/comment/dto/response/ReplayCommentDto.java
@@ -17,8 +17,10 @@ public class ReplayCommentDto {
 	private final String content;
 	private final String replyerImageUrl;
 	private final String VoteImageUrl;
+	private final Long voteId;
 
-	public static ReplayCommentDto createNotificationType(Member replyer, Member commenterOwner, Comment comment, Comment reply,
+	public static ReplayCommentDto createNotificationType(Member replyer, Member commenterOwner, Comment comment,
+		Comment reply,
 		Vote vote) {
 		return new ReplayCommentDto(
 			commenterOwner.getId(), //알림 타켓 ID
@@ -27,7 +29,8 @@ public class ReplayCommentDto {
 			replyer.getNickName().getValue(), //대댓글 작성자 ID
 			reply.getContent().getValue(),  //대댓글 내용
 			replyer.getMemberImage().getImageUrl(), //대댓글 작성자 이미지
-			vote.getVoteImage().getImageUrl() //대댓글 작성한 투표의 이미지
+			vote.getVoteImage().getImageUrl(), //대댓글 작성한 투표의 이미지
+			vote.getId()
 		);
 	}
 

--- a/src/main/java/com/salmalteam/salmal/notification/service/NotificationService.java
+++ b/src/main/java/com/salmalteam/salmal/notification/service/NotificationService.java
@@ -54,7 +54,7 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public MessageSpec save(Long targetId, Long issuedContentId, String nickName, String content, Long memberId,
+	public MessageSpec save(Long targetId, Long issuedContentId, String nickName, String content, Long contentId,
 		String memberImageUrl, String contentImageUrl) {
 
 		String message = String.format("%s님의 답댓글:%s", nickName, content);
@@ -72,6 +72,7 @@ public class NotificationService {
 		data.put("issuedContent", issuedContentId.toString());
 		data.put("notificationId", notification.getUuid());
 		data.put("createdAt", notification.getCreatedAt().toString());
+		data.put("contentId", contentId.toString());
 
 		return new MessageSpec(token, "살말", message, data);
 	}

--- a/src/main/java/com/salmalteam/salmal/presentation/http/comment/CommentController.java
+++ b/src/main/java/com/salmalteam/salmal/presentation/http/comment/CommentController.java
@@ -94,7 +94,7 @@ public class CommentController {
 		}
 		MessageSpec messageSpec = notificationService.save(
 			replayComment.getCommentOwnerId(), replayComment.getCommentId(),
-			replayComment.getNickName(), replayComment.getContent(), replayComment.getReplyerId(),
+			replayComment.getNickName(), replayComment.getContent(), replayComment.getVoteId(),
 			replayComment.getReplyerImageUrl(), replayComment.getVoteImageUrl());
 		notificationPublisher.pub(messageSpec);
 	}

--- a/src/test/java/com/salmalteam/salmal/presentation/comment/CommentControllerTest.java
+++ b/src/test/java/com/salmalteam/salmal/presentation/comment/CommentControllerTest.java
@@ -249,7 +249,7 @@ class CommentControllerTest extends PresentationTest {
             final Long commentId = 1L;
             final String content = "이 댓글에 동의합니다!";
             final CommentReplyCreateRequest commentReplyCreateRequest = new CommentReplyCreateRequest(content);
-            ReplayCommentDto replayCommentDto = new ReplayCommentDto(100L, 20L, 556L, "kim", "content","url","url");
+            ReplayCommentDto replayCommentDto = new ReplayCommentDto(100L, 20L, 556L, "kim", "content","url","url",10L);
             given(commentService.replyComment(any(),anyLong(),any()))
                 .willReturn(replayCommentDto);
             mockingForAuthorization();


### PR DESCRIPTION
# 📌 연관 이슈
- #157 
# 🧑‍💻 작업 내역

- [x] 알림 data 에 contentId 값 추가 (투표 id)

# 📚 참고 자료 (Optional)
현재 알림의 data 로 응답되는 값은 다음과 같습니다.
- `issuedContent` : 알림이 생성되게한 컨텐츠(대댓글을 단 댓글의 id)
- `notificationId` : 알림 고유 번호
- `createdAt`: : 알림 생성시각 `yy-MM-ddTHH:mm:ss`
- `contentId` : 컨텐츠 아이디 (투표 id)

# 🧐 더 나아가야할 점 혹은 고민 (Optional)
처음에는 그냥 `voteId` 라는 이름으로 할까 고민했는데 범용성 때문에 `contentId` 라고 했습니다. `issuedContent` 랑 모호하게 사용 될수 있을거 같아서 고민 했는데 그래도 `contentId` 를 사용 했습니다.