### PR TITLE
Refactoring:알림 응답 API 투표 id 추가

### DIFF
--- a/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
+++ b/src/main/java/com/salmalteam/salmal/notification/dto/response/NotificationDto.java
@@ -21,9 +21,12 @@ public class NotificationDto {
 	private final LocalDateTime createAt;
 	private final String memberImageUrl;
 	private final String imageUrl;
+	private final Long contentId;
 
 	public static NotificationDto create(Notification notification) {
 		return new NotificationDto(notification.getUuid(), notification.getMarkId(), notification.getType(),
-			notification.getMessage(), notification.isRead(), notification.getCreatedAt(), notification.getMemberImageUrl(), notification.getMarkContentImageUrl());
+			notification.getMessage(), notification.isRead(), notification.getCreatedAt(),
+			notification.getMemberImageUrl(), notification.getMarkContentImageUrl(),
+			notification.getContentId());
 	}
 }

--- a/src/main/java/com/salmalteam/salmal/notification/entity/Notification.java
+++ b/src/main/java/com/salmalteam/salmal/notification/entity/Notification.java
@@ -34,11 +34,12 @@ public class Notification extends BaseCreatedTimeEntity {
 	private boolean isRead;
 	private String memberImageUrl;
 	private String markContentImageUrl;
+	private Long contentId;
 
 	public static Notification createNewReplyType(Long memberId, Long markId, UUID uuid, String message,
-		String memberImageUrl, String markContentImageUrl) {
+		String memberImageUrl, String markContentImageUrl, Long contentId) {
 		return new Notification(null, memberId, uuid.toString(), message, markId, Type.REPLY, false, memberImageUrl,
-			markContentImageUrl);
+			markContentImageUrl, contentId);
 	}
 
 	public void read() {

--- a/src/main/java/com/salmalteam/salmal/notification/service/NotificationService.java
+++ b/src/main/java/com/salmalteam/salmal/notification/service/NotificationService.java
@@ -65,7 +65,7 @@ public class NotificationService {
 
 		Notification notification = notificationRepository.save(
 			Notification.createNewReplyType(targetId, issuedContentId, uuidGenerator.generate(), message,
-				memberImageUrl, contentImageUrl));
+				memberImageUrl, contentImageUrl, contentId));
 
 		HashMap<String, String> data = new HashMap<>();
 


### PR DESCRIPTION
# 📌 연관 이슈
- #159 
# 🧑‍💻 작업 내역

- [x] 알림 테이블 스키마 변경
- [x] 알림 조회 API 스펙 변경 

# 📚 참고 자료 (Optional)
응답API `contentId` 가 추가 되었습니다.
`contentId` :  투표 id
`markId` : 대댓글을 단 원 댓글의 id

# 🧐 더 나아가야할 점 혹은 고민 (Optional)
