### PR TITLE
Fix: 탈퇴된 사용자가 로그인되는 버그, 투표삭제가 되지않던 문제

### DIFF
--- a/src/main/java/com/salmalteam/salmal/comment/entity/Comment.java
+++ b/src/main/java/com/salmalteam/salmal/comment/entity/Comment.java
@@ -1,8 +1,26 @@
 package com.salmalteam.salmal.comment.entity;
 
-import com.salmalteam.salmal.common.entity.BaseEntity;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
 import com.salmalteam.salmal.comment.entity.like.CommentLike;
 import com.salmalteam.salmal.comment.entity.report.CommentReport;
+import com.salmalteam.salmal.common.entity.BaseEntity;
 import com.salmalteam.salmal.member.entity.Member;
 import com.salmalteam.salmal.vote.entity.Vote;
 
@@ -10,10 +28,6 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -57,7 +71,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
-    @OneToMany(mappedBy = "parentComment")
+    @OneToMany(mappedBy = "parentComment",cascade = CascadeType.REMOVE)
     private List<Comment> childComments = new ArrayList<>();
 
     public void decreaseReplyCount(final int size){

--- a/src/main/java/com/salmalteam/salmal/member/application/MemberService.java
+++ b/src/main/java/com/salmalteam/salmal/member/application/MemberService.java
@@ -57,6 +57,7 @@ public class MemberService {
 	public Long findMemberIdByProviderId(final String providerId) {
 		final Member member = memberRepository.findByProviderId(providerId)
 			.orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND));
+		validateActivatedMember(member);
 		return member.getId();
 	}
 


### PR DESCRIPTION
# 📌 연관 이슈
- #170 
- #169

# 🧑‍💻 작업 내역
- [x] `Comment` 엔티티의 `childComments`  CascadeType.REMOVE 추가
- [x]  `findMemberIdByProviderId()`  메서드 사용 시 회원탈퇴 검증 추가

# 📚 참고 자료 (Optional)
기존 대댓글의 FK 때문에 삭제안되던 문제를  투표삭제 시 CascadeType.REMOVE 옵션을 적용하여 대댓글 -> 댓글 -> 투표 순으로 삭제되게 하였습니다.
로그인 API 사용시 회원이 탈퇴한 회원인지 검증하는 로직을 추가하였습니다(탈퇴된 회원 시 기존과 동일한 예외발생)
# 🧐 더 나아가야할 점 혹은 고민 (Optional)
