### PR TITLE
Fix:탈퇴한 회원 재가입

### DIFF
--- a/src/main/java/com/salmalteam/salmal/member/application/MemberService.java
+++ b/src/main/java/com/salmalteam/salmal/member/application/MemberService.java
@@ -267,4 +267,17 @@ public class MemberService {
 			.map(member -> !member.isRemoved())
 			.orElse(false);
 	}
+
+	@Transactional
+	public Long rejoin(String provider, String providerId, String nickName, Boolean marketingInformationConsent) {
+
+		Member removedMember = memberRepository.findByProviderId(providerId)
+			.orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND));
+		removedMember.rejoin();
+
+		validateNickNameExists(nickName);
+		return memberRepository.save(
+			Member.createActivatedMember(providerId, nickName, provider, marketingInformationConsent))
+			.getId();
+	}
 }

--- a/src/main/java/com/salmalteam/salmal/member/entity/Member.java
+++ b/src/main/java/com/salmalteam/salmal/member/entity/Member.java
@@ -93,7 +93,6 @@ public class Member extends BaseEntity {
 	}
 
 	public void rejoin() {
-		nickName = NickName.rejoin();
 		providerId = "#####################";
 	}
 }

--- a/src/main/java/com/salmalteam/salmal/member/entity/Member.java
+++ b/src/main/java/com/salmalteam/salmal/member/entity/Member.java
@@ -13,6 +13,7 @@ import javax.persistence.Table;
 import com.salmalteam.salmal.common.entity.BaseEntity;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @EqualsAndHashCode(of = {"id"}, callSuper = true)
 @Table(name = "member")
 public class Member extends BaseEntity {

--- a/src/main/java/com/salmalteam/salmal/member/entity/Member.java
+++ b/src/main/java/com/salmalteam/salmal/member/entity/Member.java
@@ -89,4 +89,9 @@ public class Member extends BaseEntity {
 	public void remove() {
 		status = Status.REMOVED;
 	}
+
+	public void rejoin() {
+		nickName = NickName.rejoin();
+		providerId = "#####################";
+	}
 }

--- a/src/main/java/com/salmalteam/salmal/member/entity/NickName.java
+++ b/src/main/java/com/salmalteam/salmal/member/entity/NickName.java
@@ -1,13 +1,14 @@
 package com.salmalteam.salmal.member.entity;
 
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
 import com.salmalteam.salmal.member.exception.MemberException;
 import com.salmalteam.salmal.member.exception.MemberExceptionType;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
 
 @Getter
 @Embeddable
@@ -29,7 +30,11 @@ public class NickName {
         return new NickName(value);
     }
 
-    private void validateNickName(final String value) {
+    public static NickName rejoin() {
+        return new NickName("####################");
+    }
+
+	private void validateNickName(final String value) {
         if (isNotValidLength(value)) {
             throw new MemberException(MemberExceptionType.INVALID_NICKNAME_LENGTH);
         }

--- a/src/main/java/com/salmalteam/salmal/member/entity/NickName.java
+++ b/src/main/java/com/salmalteam/salmal/member/entity/NickName.java
@@ -30,10 +30,6 @@ public class NickName {
         return new NickName(value);
     }
 
-    public static NickName rejoin() {
-        return new NickName("####################");
-    }
-
 	private void validateNickName(final String value) {
         if (isNotValidLength(value)) {
             throw new MemberException(MemberExceptionType.INVALID_NICKNAME_LENGTH);

--- a/src/test/java/com/salmalteam/salmal/application/auth/AuthServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/auth/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.salmalteam.salmal.application.auth;
 
+import static com.salmalteam.salmal.member.entity.Provider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -7,8 +8,10 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,7 +30,13 @@ import com.salmalteam.salmal.auth.exception.AuthException;
 import com.salmalteam.salmal.auth.infrastructure.JwtProvider;
 import com.salmalteam.salmal.auth.infrastructure.RefreshTokenProvider;
 import com.salmalteam.salmal.member.application.MemberService;
+import com.salmalteam.salmal.member.entity.Introduction;
+import com.salmalteam.salmal.member.entity.Member;
+import com.salmalteam.salmal.member.entity.MemberImage;
 import com.salmalteam.salmal.member.entity.MemberRepository;
+import com.salmalteam.salmal.member.entity.NickName;
+import com.salmalteam.salmal.member.entity.Setting;
+import com.salmalteam.salmal.member.entity.Status;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -82,7 +91,6 @@ class AuthServiceTest {
 		class 회원_가입_테스트 {
 			@Test
 			void 접근_토큰과_재발급_토큰을_발급한다() {
-
 				// given
 				final Long memberId = 1L;
 				final String nickName = "닉네임";
@@ -99,6 +107,9 @@ class AuthServiceTest {
 				given(memberService.save(eq(providerId), any())).willReturn(memberId);
 				given(jwtProvider.provide(eq(payload))).willReturn(accessToken);
 				given(refreshTokenProvider.provide(eq(payload))).willReturn(refreshToken);
+				given(memberRepository.findByProviderId(anyString())).willReturn(
+					Optional.of(Member.createActivatedMember(providerId, nickName, "KAKAO",
+						true)));
 
 				// when
 				final LoginResponse loginResponse = authService.signUp(providerId, signUpRequest);
@@ -108,6 +119,50 @@ class AuthServiceTest {
 					() -> assertThat(loginResponse).isEqualTo(LoginResponse.of(accessToken, refreshToken)),
 					() -> verify(tokenRepository, times(1)).saveRefreshToken(any(RefreshToken.class))
 				);
+
+				then(memberRepository).should(times(1)).findByProviderId(anyString());
+				then(memberService).should(times(1)).save(anyString(), any(SignUpRequest.class));
+				then(jwtProvider).should(times(1)).provide(eq(payload));
+				then(refreshTokenProvider).should(times(1)).provide(eq(payload));
+			}
+
+			@Test
+			@DisplayName("탈퇴된 회원 재가입 테스트")
+			void rejoin() {
+				// given
+				final Long memberId = 100L;
+				final String nickName = "닉네임";
+				final Boolean marketingInformationConsent = false;
+				final String accessToken = "accessToken";
+				final String refreshToken = "refreshToken";
+				final String providerId = "providerId";
+				final Map<String, Object> payload = new HashMap<>();
+				payload.put("id", memberId);
+				payload.put("role", Role.MEMBER);
+				final SignUpRequest signUpRequest = new SignUpRequest(providerId, nickName,
+					marketingInformationConsent);
+				Member member = new Member(memberId, providerId, KAKAO, NickName.from(nickName), Introduction.from("test"),
+					Setting.of(true),
+					MemberImage.initMemberImage(), Status.REMOVED);
+				given(jwtProvider.provide(eq(payload))).willReturn(accessToken);
+				given(refreshTokenProvider.provide(eq(payload))).willReturn(refreshToken);
+				given(memberRepository.findByProviderId(anyString())).willReturn(Optional.of(member));
+				given(memberService.rejoin(anyString(), anyString(), anyString(), anyBoolean())).willReturn(memberId);
+				// when
+				final LoginResponse loginResponse = authService.signUp(providerId, signUpRequest);
+
+				// then
+				assertAll(
+					() -> assertThat(loginResponse).isEqualTo(LoginResponse.of(accessToken, refreshToken)),
+					() -> verify(tokenRepository, times(1)).saveRefreshToken(any(RefreshToken.class))
+				);
+
+				then(memberRepository).should(times(1)).findByProviderId(anyString());
+				then(memberService).should(times(0)).save(anyString(), any(SignUpRequest.class));
+				then(memberService).should(times(1)).rejoin(anyString(), anyString(), anyString(), anyBoolean());
+				then(jwtProvider).should(times(1)).provide(eq(payload));
+				then(refreshTokenProvider).should(times(1)).provide(eq(payload));
+
 			}
 
 			@Nested

--- a/src/test/java/com/salmalteam/salmal/application/auth/AuthServiceTest.java
+++ b/src/test/java/com/salmalteam/salmal/application/auth/AuthServiceTest.java
@@ -27,6 +27,7 @@ import com.salmalteam.salmal.auth.exception.AuthException;
 import com.salmalteam.salmal.auth.infrastructure.JwtProvider;
 import com.salmalteam.salmal.auth.infrastructure.RefreshTokenProvider;
 import com.salmalteam.salmal.member.application.MemberService;
+import com.salmalteam.salmal.member.entity.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -40,10 +41,13 @@ class AuthServiceTest {
 	TokenRepository tokenRepository;
 	@Mock
 	MemberService memberService;
+	@Mock
+	MemberRepository memberRepository;
 
 	@BeforeEach
 	void setUp() {
-		authService = new AuthService(jwtProvider, refreshTokenProvider, tokenRepository, memberService);
+		authService = new AuthService(jwtProvider, refreshTokenProvider, tokenRepository, memberService,
+			memberRepository);
 	}
 
 	@Nested


### PR DESCRIPTION
# 📌 연관 이슈
- #172 
# 🧑‍💻 작업 내역
- [x] 탈퇴한 회원 재가입 기능

# 📚 참고 자료 (Optional)
탈퇴한 회원이 재가입시 기존에 존재하는 `providerId` 를 사용하지 않는 임의 값으로 변경 후 새로운 회원정보를 DB에 저장하는 방식으로 변경,
기존 탈퇴한 회원이 생성한 투표나 댓글 정보는 그대로 남아있고 같은 `providerId` 에 새로운 pk 가 매핑되는 방식으로 변경

# 🧐 더 나아가야할 점 혹은 고민 (Optional)
